### PR TITLE
Add JSON output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ usage: tablo [-flags] [COLUMN] [COLUMN] [COLUMN]
   -nb, -no-borders                  do not draw borders
   -nh, -no-headers                  hide headers line in filter by header result
   -fi, -filter-indexes              filter columns by index
+  -j, -json                         render output as json
   -o, -output                       where to send output, can be file path or stdout
                                     (default "stdout")
 
@@ -64,6 +65,7 @@ usage: tablo [-flags] [COLUMN] [COLUMN] [COLUMN]
   $ docker images | tablo
   $ docker images | tablo REPOSITORY              # show only REPOSITORY colum
   $ docker images | tablo REPOSITORY "IMAGE ID"   # show REPOSITORY and IMAGE ID colums
+  $ docker images | tablo -j                       # render rows as json
 
   # save output to a file
   $ docker images | tablo -o /path/to/docker-images.txt REPOSITORY "IMAGE ID"
@@ -221,6 +223,24 @@ docker images | tablo
 ├───────────────────────────────────────────────────────┼────────┼──────────────┼──────────────┼────────┤
 │ ghcr.io/vbyazilim/basichttpdebugger/basichttpdebugger │ latest │ b72784c93710 │ 22 hours ago │ 12.7MB │
 └───────────────────────────────────────────────────────┴────────┴──────────────┴──────────────┴────────┘
+
+docker images | tablo -j
+[
+  {
+    "REPOSITORY": "vigo/basichttpdebugger",
+    "TAG": "latest",
+    "IMAGE ID": "911f45e85b68",
+    "CREATED": "22 hours ago",
+    "SIZE": "12.7MB"
+  },
+  {
+    "REPOSITORY": "ghcr.io/vbyazilim/basichttpdebugger/basichttpdebugger",
+    "TAG": "latest",
+    "IMAGE ID": "b72784c93710",
+    "CREATED": "22 hours ago",
+    "SIZE": "12.7MB"
+  }
+]
 ```
 
 You can also filter if your input has a kind of header row:
@@ -355,14 +375,17 @@ rake test            # run test
 
 **2025-02-02**
 
-- add `json` support
-- add `json` filtering
 - add sorting such as `-sort <FIELD>`
 - add `ls` support, such as `-where -size > 10mb`, `-sort ...`
 
 ---
 
 ## Change Log
+
+**2026-05-10**
+
+- add `-j` / `-json` output mode
+- emit arrays of objects when input has a header row, otherwise arrays of arrays
 
 **2026-05-02**
 

--- a/internal/tablo/json_internal_test.go
+++ b/internal/tablo/json_internal_test.go
@@ -1,0 +1,110 @@
+package tablo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type errorWriteCloser struct {
+	err error
+}
+
+func (e *errorWriteCloser) Write([]byte) (int, error) {
+	return 0, e.err
+}
+
+func (e *errorWriteCloser) Close() error {
+	return nil
+}
+
+func TestPickFieldsByIndices_OutOfRange(t *testing.T) {
+	fields := pickFieldsByIndices([]string{"foo"}, []int{0, 1})
+
+	assert.Equal(t, []string{"foo", ""}, fields)
+}
+
+func TestTablo_SelectFields_ColumnIndices_OutOfRange(t *testing.T) {
+	tbl := &Tablo{}
+
+	fields := tbl.selectFields([]string{"foo"}, []int{0, 1})
+
+	assert.Equal(t, []string{"foo", ""}, fields)
+}
+
+func TestTablo_SelectFields_FilterIndexes_OutOfRange(t *testing.T) {
+	tbl := &Tablo{
+		FilterIndexes: []int{1, 2},
+	}
+
+	fields := tbl.selectFields([]string{"foo", "bar"}, nil)
+
+	assert.Equal(t, []string{"bar", ""}, fields)
+}
+
+func TestTablo_BuildJSONDataset_EmptyLines(t *testing.T) {
+	tbl := &Tablo{}
+
+	dataset := tbl.buildJSONDataset(nil)
+
+	assert.Equal(t, jsonDataset{rows: [][]string{}}, dataset)
+}
+
+func TestTablo_BuildJSONDataset_WithSelectedHeaders(t *testing.T) {
+	tbl := &Tablo{
+		Args:           []string{"name", "age"},
+		FieldDelimiter: '|',
+	}
+
+	dataset := tbl.buildJSONDataset([]string{"name|age|city", "vigo"})
+
+	assert.True(t, dataset.hasHeader)
+	assert.Equal(t, []string{"name", "age"}, dataset.headers)
+	assert.Equal(t, [][]string{{"vigo", ""}}, dataset.rows)
+}
+
+func TestLooksLikeHeader(t *testing.T) {
+	assert.True(t, looksLikeHeader([]string{"name", "age"}))
+	assert.False(t, looksLikeHeader([]string{"nobody", "*", "/usr/bin/false"}))
+	assert.False(t, looksLikeHeader([]string{"single value"}))
+}
+
+func TestTablo_BuildJSONDataset_FilterIndexesTakePrecedence(t *testing.T) {
+	tbl := &Tablo{
+		Args:           []string{"name"},
+		FieldDelimiter: '|',
+		FilterIndexes:  []int{1},
+	}
+
+	dataset := tbl.buildJSONDataset([]string{"name|age", "vigo|42"})
+
+	assert.False(t, dataset.hasHeader)
+	assert.Empty(t, dataset.headers)
+	assert.Equal(t, [][]string{{"age"}, {"42"}}, dataset.rows)
+}
+
+func TestTablo_RenderJSON_WithoutHeaders_ReturnsWriteError(t *testing.T) {
+	writeErr := errors.New("write failed")
+	tbl := &Tablo{
+		Output:         &errorWriteCloser{err: writeErr},
+		FieldDelimiter: '|',
+		FilterIndexes:  []int{1},
+	}
+
+	err := tbl.renderJSON([]string{"hello|world"})
+
+	assert.ErrorIs(t, err, writeErr)
+}
+
+func TestTablo_RenderJSON_WithHeaders_ReturnsWriteError(t *testing.T) {
+	writeErr := errors.New("write failed")
+	tbl := &Tablo{
+		Output:         &errorWriteCloser{err: writeErr},
+		FieldDelimiter: '|',
+	}
+
+	err := tbl.renderJSON([]string{"name|age", "vigo|42"})
+
+	assert.ErrorIs(t, err, writeErr)
+}

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -204,6 +204,42 @@ func (t *Tablo) selectFields(fields []string, columnIndices []int) []string {
 	return selectedFields
 }
 
+func isHeaderLikeField(field string) bool {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return false
+	}
+
+	for i, r := range field {
+		switch {
+		case r == ' ' || r == '_' || r == '-':
+			continue
+		case i == 0 && (r < 'A' || (r > 'Z' && r < 'a') || r > 'z'):
+			return false
+		case (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			continue
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+func looksLikeHeader(fields []string) bool {
+	if len(fields) <= 1 {
+		return false
+	}
+
+	for _, field := range fields {
+		if !isHeaderLikeField(field) {
+			return false
+		}
+	}
+
+	return true
+}
+
 type jsonDataset struct {
 	headers   []string
 	rows      [][]string
@@ -212,17 +248,21 @@ type jsonDataset struct {
 
 func (t *Tablo) buildJSONDataset(lines []string) jsonDataset {
 	if len(lines) == 0 {
-		return jsonDataset{}
+		return jsonDataset{
+			rows: [][]string{},
+		}
 	}
 
 	headers := t.splitFields(lines[0])
 	columnIndices := t.selectColumnIndices(headers)
 
-	dataset := jsonDataset{}
-	if len(columnIndices) > 0 {
+	dataset := jsonDataset{
+		rows: make([][]string, 0, len(lines)),
+	}
+	if len(t.FilterIndexes) == 0 && len(columnIndices) > 0 {
 		dataset.headers = pickFieldsByIndices(headers, columnIndices)
 		dataset.hasHeader = true
-	} else if len(lines) > 1 && len(t.FilterIndexes) == 0 {
+	} else if len(t.FilterIndexes) == 0 && looksLikeHeader(headers) {
 		dataset.headers = headers
 		dataset.hasHeader = true
 	}

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -5,6 +5,8 @@ package tablo
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -25,6 +27,7 @@ var _ Tablizer = (*Tablo)(nil) // compile time proof
 const (
 	breakTextForUnix    = "press ENTER and CTRL+D to finish text entry"
 	breakTextForWindows = "press CTRL+Z and ENTER to finish text entry"
+	errorWrapFormat     = "%w"
 
 	helpOutput             = "where to send output, can be file path or stdout"
 	helpLineDelimiterChar  = "line delimiter char to split the input"
@@ -33,6 +36,7 @@ const (
 	helpNoBorders          = "do not draw borders"
 	helpNoHeaders          = "hide headers line in filter by header result"
 	helpFilterIndexes      = "filter columns by index"
+	helpJSONOutput         = "render output as json"
 
 	defaultOutput        = "stdout"
 	defaultLineDelimiter = '\n'
@@ -97,7 +101,7 @@ type ReadInputFunc func(io.Reader) (string, error)
 func isFile(filename string) error {
 	fileInfo, err := os.Stat(filename)
 	if err != nil {
-		return fmt.Errorf("%w", err)
+		return fmt.Errorf(errorWrapFormat, err)
 	}
 
 	fileMode := fileInfo.Mode()
@@ -112,7 +116,7 @@ func readInput(input io.Reader) (string, error) {
 	r := bufio.NewReader(input)
 	b, err := io.ReadAll(r)
 	if err != nil {
-		return "", fmt.Errorf("%w", err)
+		return "", fmt.Errorf(errorWrapFormat, err)
 	}
 
 	if len(b) == 0 {
@@ -129,7 +133,185 @@ func stringSliceToRow(fields []string) table.Row {
 	for i, v := range fields {
 		row[i] = v
 	}
+
 	return row
+}
+
+func (t *Tablo) splitFields(line string) []string {
+	if t.FieldDelimiter == 0 {
+		return spaceSplitter(defaultSpaceAmount).Split(line, -1)
+	}
+
+	return strings.Split(line, string(t.FieldDelimiter))
+}
+
+func (t *Tablo) selectColumnIndices(headers []string) []int {
+	if len(headers) == 0 || len(t.Args) == 0 {
+		return nil
+	}
+
+	var columnIndices []int
+	for _, arg := range t.Args {
+		for idx, header := range headers {
+			if strings.EqualFold(header, arg) {
+				columnIndices = append(columnIndices, idx)
+				break
+			}
+		}
+	}
+
+	return columnIndices
+}
+
+func pickFieldsByIndices(fields []string, indices []int) []string {
+	var selectedFields []string
+
+	for _, idx := range indices {
+		if idx < len(fields) {
+			selectedFields = append(selectedFields, fields[idx])
+		} else {
+			selectedFields = append(selectedFields, "")
+		}
+	}
+
+	return selectedFields
+}
+
+func (t *Tablo) selectFields(fields []string, columnIndices []int) []string {
+	var selectedFields []string
+
+	switch {
+	case len(t.FilterIndexes) > 0:
+		for _, idx := range t.FilterIndexes {
+			if idx >= 0 && idx < len(fields) {
+				selectedFields = append(selectedFields, fields[idx])
+			} else {
+				selectedFields = append(selectedFields, "")
+			}
+		}
+	case len(columnIndices) > 0:
+		for _, idx := range columnIndices {
+			if idx < len(fields) {
+				selectedFields = append(selectedFields, fields[idx])
+			} else {
+				selectedFields = append(selectedFields, "")
+			}
+		}
+	default:
+		selectedFields = fields
+	}
+
+	return selectedFields
+}
+
+type jsonDataset struct {
+	headers   []string
+	rows      [][]string
+	hasHeader bool
+}
+
+func (t *Tablo) buildJSONDataset(lines []string) jsonDataset {
+	if len(lines) == 0 {
+		return jsonDataset{}
+	}
+
+	headers := t.splitFields(lines[0])
+	columnIndices := t.selectColumnIndices(headers)
+
+	dataset := jsonDataset{}
+	if len(columnIndices) > 0 {
+		dataset.headers = pickFieldsByIndices(headers, columnIndices)
+		dataset.hasHeader = true
+	} else if len(lines) > 1 && len(t.FilterIndexes) == 0 {
+		dataset.headers = headers
+		dataset.hasHeader = true
+	}
+
+	start := 0
+	if dataset.hasHeader {
+		start = 1
+	}
+
+	for i := start; i < len(lines); i++ {
+		fields := t.splitFields(lines[i])
+		dataset.rows = append(dataset.rows, t.selectFields(fields, columnIndices))
+	}
+
+	return dataset
+}
+
+func writeJSONString(buf *bytes.Buffer, value string) error {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf(errorWrapFormat, err)
+	}
+
+	_, err = buf.Write(b)
+	if err != nil {
+		return fmt.Errorf(errorWrapFormat, err)
+	}
+
+	return nil
+}
+
+func (t *Tablo) renderJSON(lines []string) error {
+	dataset := t.buildJSONDataset(lines)
+
+	if !dataset.hasHeader {
+		b, err := json.MarshalIndent(dataset.rows, "", "  ")
+		if err != nil {
+			return fmt.Errorf(errorWrapFormat, err)
+		}
+
+		_, err = fmt.Fprintf(t.Output, "%s\n", b)
+		if err != nil {
+			return fmt.Errorf(errorWrapFormat, err)
+		}
+
+		return nil
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("[\n")
+
+	for i, row := range dataset.rows {
+		buf.WriteString("  {\n")
+		for j, header := range dataset.headers {
+			buf.WriteString("    ")
+			if err := writeJSONString(&buf, header); err != nil {
+				return err
+			}
+			buf.WriteString(": ")
+
+			value := ""
+			if j < len(row) {
+				value = row[j]
+			}
+			if err := writeJSONString(&buf, value); err != nil {
+				return err
+			}
+
+			if j < len(dataset.headers)-1 {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+
+		buf.WriteString("  }")
+		if i < len(dataset.rows)-1 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+
+	buf.WriteString("]\n")
+
+	_, err := t.Output.Write(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf(errorWrapFormat, err)
+	}
+
+	return nil
 }
 
 // Tablo holds the required params.
@@ -145,6 +327,7 @@ type Tablo struct {
 	SeparateRows   bool
 	DrawBorder     bool
 	HideHeaders    bool
+	JSONOutput     bool
 }
 
 func (t *Tablo) setDefaults() {
@@ -166,7 +349,7 @@ var (
 func (t *Tablo) parseArgs() (string, error) {
 	finfo, finfoErr := os.Stdin.Stat()
 	if finfoErr != nil {
-		return "", fmt.Errorf("%w", finfoErr)
+		return "", fmt.Errorf(errorWrapFormat, finfoErr)
 	}
 
 	if len(t.Args) == 0 || (len(t.Args) > 0 && IsNamedPipe(finfo)) {
@@ -192,7 +375,7 @@ func (t *Tablo) getReadFrom() (*os.File, error) {
 	if fileArg != "" {
 		file, errF := os.Open(filepath.Clean(fileArg))
 		if errF != nil {
-			return nil, fmt.Errorf("%w", errF)
+			return nil, fmt.Errorf(errorWrapFormat, errF)
 		}
 
 		readFrom = file
@@ -201,7 +384,7 @@ func (t *Tablo) getReadFrom() (*os.File, error) {
 	if readFrom == os.Stdin {
 		finfo, finfoErr := os.Stdin.Stat()
 		if finfoErr != nil {
-			return nil, fmt.Errorf("%w", finfoErr)
+			return nil, fmt.Errorf(errorWrapFormat, finfoErr)
 		}
 
 		if IsCharDevice(finfo) {
@@ -221,31 +404,11 @@ func (t *Tablo) processHeaders(tw table.Writer, lines []string) []int {
 		return nil
 	}
 
-	var headers []string
-	var columnIndices []int
-
-	if t.FieldDelimiter == 0 {
-		headers = spaceSplitter(defaultSpaceAmount).Split(lines[0], -1)
-	} else {
-		headers = strings.Split(lines[0], string(t.FieldDelimiter))
-	}
-
-	for _, arg := range t.Args {
-		for idx, header := range headers {
-			if strings.EqualFold(header, arg) {
-				columnIndices = append(columnIndices, idx)
-				break
-			}
-		}
-	}
+	headers := t.splitFields(lines[0])
+	columnIndices := t.selectColumnIndices(headers)
 
 	if len(columnIndices) > 0 {
-		var selectedHeaders []string
-		for _, idx := range columnIndices {
-			if idx < len(headers) {
-				selectedHeaders = append(selectedHeaders, headers[idx])
-			}
-		}
+		selectedHeaders := pickFieldsByIndices(headers, columnIndices)
 		if !t.HideHeaders {
 			tw.AppendHeader(stringSliceToRow(selectedHeaders))
 		}
@@ -261,46 +424,12 @@ func (t *Tablo) processHeaders(tw table.Writer, lines []string) []int {
 }
 
 func (t *Tablo) processRows(tw table.Writer, lines []string, columnIndices []int) {
-	columnIndicesLen := len(columnIndices)
-	filterIndexesLen := len(t.FilterIndexes)
-
 	for i, line := range lines {
 		if len(t.Args) > 0 && i == 0 {
 			continue
 		}
-		var fields []string
-
-		if t.FieldDelimiter == 0 {
-			fields = spaceSplitter(defaultSpaceAmount).Split(line, -1)
-		} else {
-			fields = strings.Split(line, string(t.FieldDelimiter))
-		}
-
-		var selectedFields []string
-
-		switch {
-		case filterIndexesLen > 0:
-			for _, idx := range t.FilterIndexes {
-				if idx >= 0 && idx < len(fields) {
-					selectedFields = append(selectedFields, fields[idx])
-				} else {
-					selectedFields = append(selectedFields, "")
-				}
-			}
-
-		case columnIndicesLen > 0:
-			for _, idx := range columnIndices {
-				if idx < len(fields) {
-					selectedFields = append(selectedFields, fields[idx])
-				} else {
-					selectedFields = append(selectedFields, "")
-				}
-			}
-
-		default:
-			selectedFields = fields
-		}
-
+		fields := t.splitFields(line)
+		selectedFields := t.selectFields(fields, columnIndices)
 		tw.AppendRow(stringSliceToRow(selectedFields))
 	}
 }
@@ -337,6 +466,10 @@ func (t *Tablo) Tabelize() error {
 			continue
 		}
 		lines = append(lines, line)
+	}
+
+	if t.JSONOutput {
+		return t.renderJSON(lines)
 	}
 
 	drawBorders := !t.DrawBorder
@@ -502,6 +635,15 @@ func WithNoHeaders(hide bool) Option {
 	}
 }
 
+// WithJSONOutput renders output as JSON.
+func WithJSONOutput(enabled bool) Option {
+	return func(t *Tablo) error {
+		t.JSONOutput = enabled
+
+		return nil
+	}
+}
+
 // WithFilterIndexes sets the filter index columns.
 func WithFilterIndexes(indexes string) Option {
 	return func(t *Tablo) error {
@@ -570,11 +712,14 @@ func Run() error {
 	filterIndexes := flag.String("filter-indexes", "", helpFilterIndexes)
 	flag.StringVar(filterIndexes, "fi", "", helpFilterIndexes+" (short)")
 
+	jsonOutput := flag.Bool("json", false, helpJSONOutput)
+	flag.BoolVar(jsonOutput, "j", false, helpJSONOutput+" (short)")
+
 	output := flag.String("output", defaultOutput, helpOutput)
 	flag.StringVar(output, "o", defaultOutput, helpOutput+" (short)")
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
-		return fmt.Errorf("%w", err)
+		return fmt.Errorf(errorWrapFormat, err)
 	}
 
 	tbl, err := New(
@@ -588,6 +733,7 @@ func Run() error {
 		WithNoDrawBorder(*noBorders),
 		WithNoHeaders(*noHeaders),
 		WithFilterIndexes(*filterIndexes),
+		WithJSONOutput(*jsonOutput),
 	)
 	if err != nil {
 		return err

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -851,6 +851,103 @@ func TestRun_ReadFromFile_SaveToFile(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(result))
 }
 
+func TestTablo_Tabelize_JSONOutput_WithHeaders(t *testing.T) {
+	input := bytes.NewBufferString("name|age\nvigo|42\njohn|7\n")
+	output := new(BytesWriteCloser)
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter("|"),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithJSONOutput(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := `[
+  {
+    "name": "vigo",
+    "age": "42"
+  },
+  {
+    "name": "john",
+    "age": "7"
+  }
+]
+`
+	assert.Equal(t, expectedOutput, string(output.nonStdinValue()))
+}
+
+func TestTablo_Tabelize_JSONOutput_WithoutHeaders(t *testing.T) {
+	input := bytes.NewBufferString("hello|world\n")
+	output := new(BytesWriteCloser)
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter("|"),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithFilterIndexes("2,1"),
+		tablo.WithJSONOutput(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := `[
+  [
+    "world",
+    "hello"
+  ]
+]
+`
+	assert.Equal(t, expectedOutput, string(output.nonStdinValue()))
+}
+
+func TestRun_ReadFromFile_SaveToJSONFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test_input.txt")
+	assert.NoError(t, err)
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	_, err = tmpFile.WriteString("name|age\nvigo|42\n")
+	assert.NoError(t, err)
+	_ = tmpFile.Close()
+
+	outputFile, err := os.CreateTemp("", "output.json")
+	assert.NoError(t, err)
+	defer func() { _ = os.Remove(outputFile.Name()) }()
+
+	os.Args = []string{"tablo", "-j", "-f", "|", "-o", outputFile.Name(), tmpFile.Name()}
+	resetFlags()
+
+	err = tablo.Run()
+	assert.NoError(t, err)
+
+	result, err := os.ReadFile(outputFile.Name())
+	assert.NoError(t, err)
+
+	expectedOutput := `[
+  {
+    "name": "vigo",
+    "age": "42"
+  }
+]
+`
+	assert.Equal(t, expectedOutput, string(result))
+}
+
 func TestTablo_Tabelize_FieldDelimiter_Space_ExactSplit(t *testing.T) {
 	input := bytes.NewBufferString("foo bar\n")
 	output := new(BytesWriteCloser)

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -948,6 +948,71 @@ func TestRun_ReadFromFile_SaveToJSONFile(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(result))
 }
 
+func TestTablo_Tabelize_JSONOutput_WithoutHeaderRow_KeepsFirstRow(t *testing.T) {
+	input := bytes.NewBufferString("nobody:*:-2:-2:Unprivileged User:/var/empty:/usr/bin/false\nroot:*:0:0:System Administrator:/var/root:/bin/sh\n")
+	output := new(BytesWriteCloser)
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter(":"),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithJSONOutput(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := `[
+  [
+    "nobody",
+    "*",
+    "-2",
+    "-2",
+    "Unprivileged User",
+    "/var/empty",
+    "/usr/bin/false"
+  ],
+  [
+    "root",
+    "*",
+    "0",
+    "0",
+    "System Administrator",
+    "/var/root",
+    "/bin/sh"
+  ]
+]
+`
+	assert.Equal(t, expectedOutput, string(output.nonStdinValue()))
+}
+
+func TestTablo_Tabelize_JSONOutput_EmptyInput_ReturnsArray(t *testing.T) {
+	output := new(BytesWriteCloser)
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithJSONOutput(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return "", nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "[]\n", string(output.nonStdinValue()))
+}
+
 func TestTablo_Tabelize_FieldDelimiter_Space_ExactSplit(t *testing.T) {
 	input := bytes.NewBufferString("foo bar\n")
 	output := new(BytesWriteCloser)

--- a/internal/tablo/usage.go
+++ b/internal/tablo/usage.go
@@ -21,7 +21,7 @@ const usage = `usage: %[1]s [-flags] [COLUMN] [COLUMN] [COLUMN]
   -fi, -filter-indexes              %s
   -j, -json                         %s
   -o, -output                       %s
-                                     (default "stdout")
+                                    (default "stdout")
 
   examples:
 

--- a/internal/tablo/usage.go
+++ b/internal/tablo/usage.go
@@ -19,8 +19,9 @@ const usage = `usage: %[1]s [-flags] [COLUMN] [COLUMN] [COLUMN]
   -nb, -no-borders                  %s
   -nh, -no-headers                  %s
   -fi, -filter-indexes              %s
+  -j, -json                         %s
   -o, -output                       %s
-                                    (default "stdout")
+                                     (default "stdout")
 
   examples:
 
@@ -39,6 +40,7 @@ const usage = `usage: %[1]s [-flags] [COLUMN] [COLUMN] [COLUMN]
   $ docker images | %[1]s
   $ docker images | %[1]s REPOSITORY              # show only REPOSITORY colum
   $ docker images | %[1]s REPOSITORY "IMAGE ID"   # show REPOSITORY and IMAGE ID colums
+  $ docker images | %[1]s -j                       # render rows as json
 
   # save output to a file
   $ docker images | %[1]s -o /path/to/docker-images.txt REPOSITORY "IMAGE ID"
@@ -73,6 +75,7 @@ func showUsage() {
 		helpNoBorders,
 		helpNoHeaders,
 		helpFilterIndexes,
+		helpJSONOutput,
 		helpOutput,
 	}
 	fmt.Fprintf(flag.CommandLine.Output(), usage, args...)


### PR DESCRIPTION
## Summary
- add `-j` / `-json` output mode
- render arrays of objects for headered input and arrays of arrays otherwise
- document the new mode and remove completed JSON TODO items