### PR TITLE
Fix no-headers handling for detected CSV headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ usage: tablo [-flags] [COLUMN] [COLUMN] [COLUMN]
                                     (default: "\n")
   -n, -no-separate-rows             do not draw separation line under rows
   -nb, -no-borders                  do not draw borders
-  -nh, -no-headers                  hide headers line in filter by header result
+  -nh, -no-headers                  hide the selected or detected header row
   -fi, -filter-indexes              filter columns by index
   -j, -json                         render output as json
   -o, -output                       where to send output, can be file path or stdout
@@ -312,6 +312,15 @@ cat /path/to/username.csv | tablo -f ";"
 cat /path/to/username.csv | tablo -f ";" -n
 ┌───────────┬────────────┬────────────┬───────────┐
 │ Username  │ Identifier │ First name │ Last name │
+│ booker12  │ 9012       │ Rachel     │ Booker    │
+│ grey07    │ 2070       │ Laura      │ Grey      │
+│ johnson81 │ 4081       │ Craig      │ Johnson   │
+│ jenkins46 │ 9346       │ Mary       │ Jenkins   │
+│ smith79   │ 5079       │ Jamie      │ Smith     │
+└───────────┴────────────┴────────────┴───────────┘
+
+cat /path/to/username.csv | tablo -f ";" -n -nh
+┌───────────┬────────────┬────────────┬───────────┐
 │ booker12  │ 9012       │ Rachel     │ Booker    │
 │ grey07    │ 2070       │ Laura      │ Grey      │
 │ johnson81 │ 4081       │ Craig      │ Johnson   │

--- a/README.md
+++ b/README.md
@@ -322,13 +322,13 @@ cat /path/to/username.csv | tablo -f ";" -n
 └───────────┴────────────┴────────────┴───────────┘
 
 cat /path/to/username.csv | tablo -f ";" -n -nh
-┌───────────┬────────────┬────────────┬───────────┐
-│ booker12  │ 9012       │ Rachel     │ Booker    │
-│ grey07    │ 2070       │ Laura      │ Grey      │
-│ johnson81 │ 4081       │ Craig      │ Johnson   │
-│ jenkins46 │ 9346       │ Mary       │ Jenkins   │
-│ smith79   │ 5079       │ Jamie      │ Smith     │
-└───────────┴────────────┴────────────┴───────────┘
+┌───────────┬──────┬────────┬─────────┐
+│ booker12  │ 9012 │ Rachel │ Booker  │
+│ grey07    │ 2070 │ Laura  │ Grey    │
+│ johnson81 │ 4081 │ Craig  │ Johnson │
+│ jenkins46 │ 9346 │ Mary   │ Jenkins │
+│ smith79   │ 5079 │ Jamie  │ Smith   │
+└───────────┴──────┴────────┴─────────┘
 
 cat /path/to/username.csv | tablo -f ";" -n username
 ┌───────────┐

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ this is line
 - **Smart mode** (when `-f` is omitted): splits on **2 or more consecutive
   whitespace characters**. This is ideal for aligned column output from tools
   like `docker images`, `ps aux`, `ls -l`, where cell values may contain a
-  single space (e.g. `"2 weeks ago"`, `"Up 22 hours"`).
+  single space (e.g. `"2 weeks ago"`, `"Up 22 hours"`). When the input looks
+  like delimited data (CSV/TSV or similar), `tablo` auto-detects common
+  delimiters such as `,`, `;`, tab, and `|`.
 - **Exact mode** (when `-f <char>` is given): splits on **each occurrence** of
   the given character. Consecutive delimiters preserve empty cells, matching
   CSV semantics.

--- a/internal/tablo/json_internal_test.go
+++ b/internal/tablo/json_internal_test.go
@@ -82,12 +82,33 @@ func TestTablo_DetectFieldDelimiter(t *testing.T) {
 	assert.Equal(t, ',', delimiter)
 }
 
+func TestTablo_DetectFieldDelimiter_UsesConfiguredDelimiter(t *testing.T) {
+	tbl := &Tablo{
+		FieldDelimiter: ';',
+	}
+
+	delimiter := tbl.detectFieldDelimiter([]string{"name,age", "vigo,42"})
+
+	assert.Equal(t, ';', delimiter)
+}
+
 func TestTablo_DetectFieldDelimiter_DoesNotAssumeQuotedCSVParsing(t *testing.T) {
 	tbl := &Tablo{}
 
 	delimiter := tbl.detectFieldDelimiter([]string{
 		`name,notes`,
 		`vigo,"a,b"`,
+	})
+
+	assert.Equal(t, rune(0), delimiter)
+}
+
+func TestTablo_DetectFieldDelimiter_MismatchedFieldCountsReturnZero(t *testing.T) {
+	tbl := &Tablo{}
+
+	delimiter := tbl.detectFieldDelimiter([]string{
+		"name,age",
+		"vigo,42,istanbul",
 	})
 
 	assert.Equal(t, rune(0), delimiter)
@@ -145,6 +166,16 @@ func TestTablo_ShouldSkipFirstRow_FilterIndexesTakePrecedence(t *testing.T) {
 	}
 
 	skip := tbl.shouldSkipFirstRow([]string{"name|age", "vigo|42"})
+
+	assert.False(t, skip)
+}
+
+func TestTablo_ShouldSkipFirstRow_NoHeadersInSmartMode_DoesNotSkip(t *testing.T) {
+	tbl := &Tablo{
+		HideHeaders: true,
+	}
+
+	skip := tbl.shouldSkipFirstRow([]string{"name  age", "vigo  42"})
 
 	assert.False(t, skip)
 }

--- a/internal/tablo/json_internal_test.go
+++ b/internal/tablo/json_internal_test.go
@@ -66,8 +66,33 @@ func TestTablo_BuildJSONDataset_WithSelectedHeaders(t *testing.T) {
 
 func TestLooksLikeHeader(t *testing.T) {
 	assert.True(t, looksLikeHeader([]string{"name", "age"}))
+	assert.True(t, looksLikeHeader([]string{"ID", `"T.C. KİMLİK NO"`, "-BÖLÜM", `"_ADI SOYADI"`}))
 	assert.False(t, looksLikeHeader([]string{"nobody", "*", "/usr/bin/false"}))
 	assert.False(t, looksLikeHeader([]string{"single value"}))
+}
+
+func TestTablo_DetectFieldDelimiter(t *testing.T) {
+	tbl := &Tablo{}
+
+	delimiter := tbl.detectFieldDelimiter([]string{
+		`ID,"name",department`,
+		`1,"vigo",engineering`,
+	})
+
+	assert.Equal(t, ',', delimiter)
+}
+
+func TestTablo_BuildJSONDataset_AutoDetectsCSVDelimiter(t *testing.T) {
+	tbl := &Tablo{}
+
+	dataset := tbl.buildJSONDataset([]string{
+		`name,age`,
+		`vigo,42`,
+	})
+
+	assert.True(t, dataset.hasHeader)
+	assert.Equal(t, []string{"name", "age"}, dataset.headers)
+	assert.Equal(t, [][]string{{"vigo", "42"}}, dataset.rows)
 }
 
 func TestTablo_BuildJSONDataset_FilterIndexesTakePrecedence(t *testing.T) {

--- a/internal/tablo/json_internal_test.go
+++ b/internal/tablo/json_internal_test.go
@@ -82,6 +82,17 @@ func TestTablo_DetectFieldDelimiter(t *testing.T) {
 	assert.Equal(t, ',', delimiter)
 }
 
+func TestTablo_DetectFieldDelimiter_DoesNotAssumeQuotedCSVParsing(t *testing.T) {
+	tbl := &Tablo{}
+
+	delimiter := tbl.detectFieldDelimiter([]string{
+		`name,notes`,
+		`vigo,"a,b"`,
+	})
+
+	assert.Equal(t, rune(0), delimiter)
+}
+
 func TestTablo_BuildJSONDataset_AutoDetectsCSVDelimiter(t *testing.T) {
 	tbl := &Tablo{}
 

--- a/internal/tablo/json_internal_test.go
+++ b/internal/tablo/json_internal_test.go
@@ -109,6 +109,35 @@ func TestTablo_BuildJSONDataset_FilterIndexesTakePrecedence(t *testing.T) {
 	assert.Equal(t, [][]string{{"age"}, {"42"}}, dataset.rows)
 }
 
+func TestTablo_BuildJSONDataset_FilterIndexesWithNoHeaders_SkipsDetectedHeaderRow(t *testing.T) {
+	tbl := &Tablo{
+		FieldDelimiter: ';',
+		FilterIndexes:  []int{0, 2},
+		HideHeaders:    true,
+	}
+
+	dataset := tbl.buildJSONDataset([]string{
+		"Username;Identifier;First name;Last name",
+		"booker12;9012;Rachel;Booker",
+		"grey07;2070;Laura;Grey",
+	})
+
+	assert.False(t, dataset.hasHeader)
+	assert.Empty(t, dataset.headers)
+	assert.Equal(t, [][]string{{"booker12", "Rachel"}, {"grey07", "Laura"}}, dataset.rows)
+}
+
+func TestTablo_ShouldSkipFirstRow_FilterIndexesTakePrecedence(t *testing.T) {
+	tbl := &Tablo{
+		Args:          []string{"name"},
+		FilterIndexes: []int{1},
+	}
+
+	skip := tbl.shouldSkipFirstRow([]string{"name|age", "vigo|42"})
+
+	assert.False(t, skip)
+}
+
 func TestTablo_RenderJSON_WithoutHeaders_ReturnsWriteError(t *testing.T) {
 	writeErr := errors.New("write failed")
 	tbl := &Tablo{

--- a/internal/tablo/json_internal_test.go
+++ b/internal/tablo/json_internal_test.go
@@ -114,6 +114,17 @@ func TestTablo_DetectFieldDelimiter_MismatchedFieldCountsReturnZero(t *testing.T
 	assert.Equal(t, rune(0), delimiter)
 }
 
+func TestTablo_DetectFieldDelimiter_PreservesLeadingAndTrailingTabs(t *testing.T) {
+	tbl := &Tablo{}
+
+	delimiter := tbl.detectFieldDelimiter([]string{
+		"\tname\tage\t",
+		"\tvigo\t42\t",
+	})
+
+	assert.Equal(t, '\t', delimiter)
+}
+
 func TestTablo_BuildJSONDataset_AutoDetectsCSVDelimiter(t *testing.T) {
 	tbl := &Tablo{}
 

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -541,14 +541,14 @@ func (t *Tablo) shouldSkipFirstRow(lines []string) bool {
 	}
 
 	if len(t.FilterIndexes) > 0 {
-		return t.HideHeaders && looksLikeHeader(t.splitFields(lines[0]))
+		return t.HideHeaders && t.FieldDelimiter != 0 && looksLikeHeader(t.splitFields(lines[0]))
 	}
 
 	if len(t.Args) > 0 {
 		return true
 	}
 
-	if !t.HideHeaders {
+	if !t.HideHeaders || t.FieldDelimiter == 0 {
 		return false
 	}
 

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -147,24 +147,6 @@ func (t *Tablo) splitFields(line string) []string {
 	return strings.Split(line, string(t.FieldDelimiter))
 }
 
-func countDelimiterOutsideQuotes(line string, delimiter rune) int {
-	count := 0
-	inQuotes := false
-
-	for _, r := range line {
-		switch r {
-		case '"':
-			inQuotes = !inQuotes
-		case delimiter:
-			if !inQuotes {
-				count++
-			}
-		}
-	}
-
-	return count
-}
-
 func (t *Tablo) detectFieldDelimiter(lines []string) rune {
 	if t.FieldDelimiter != 0 {
 		return t.FieldDelimiter
@@ -183,7 +165,7 @@ func (t *Tablo) detectFieldDelimiter(lines []string) rune {
 				continue
 			}
 
-			currentCount := countDelimiterOutsideQuotes(line, candidate) + 1
+			currentCount := strings.Count(line, string(candidate)) + 1
 			if currentCount <= 1 {
 				fieldCount = 0
 				break
@@ -275,7 +257,6 @@ func (t *Tablo) selectFields(fields []string, columnIndices []int) []string {
 }
 
 func isHeaderLikeField(field string) bool {
-	field = strings.TrimSpace(field)
 	field = strings.Trim(field, `"'`)
 	field = strings.TrimLeft(field, "_-")
 	field = strings.TrimSpace(field)

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -499,7 +499,7 @@ func (t *Tablo) getReadFrom() (*os.File, error) {
 }
 
 func (t *Tablo) processHeaders(tw table.Writer, lines []string) []int {
-	if len(lines) == 0 || len(t.Args) == 0 {
+	if len(lines) == 0 || len(t.FilterIndexes) > 0 || len(t.Args) == 0 {
 		return nil
 	}
 
@@ -513,8 +513,10 @@ func (t *Tablo) processHeaders(tw table.Writer, lines []string) []int {
 		}
 	} else {
 		if len(lines) > 1 {
-			tw.AppendHeader(stringSliceToRow(headers))
-		} else {
+			if !t.HideHeaders {
+				tw.AppendHeader(stringSliceToRow(headers))
+			}
+		} else if !t.HideHeaders {
 			tw.AppendRow(stringSliceToRow(headers))
 		}
 	}

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -41,6 +42,7 @@ const (
 	defaultOutput        = "stdout"
 	defaultLineDelimiter = '\n'
 	defaultSpaceAmount   = 2
+	delimiterProbeLines  = 5
 )
 
 // sentinel errors.
@@ -145,6 +147,74 @@ func (t *Tablo) splitFields(line string) []string {
 	return strings.Split(line, string(t.FieldDelimiter))
 }
 
+func countDelimiterOutsideQuotes(line string, delimiter rune) int {
+	count := 0
+	inQuotes := false
+
+	for _, r := range line {
+		switch r {
+		case '"':
+			inQuotes = !inQuotes
+		case delimiter:
+			if !inQuotes {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+func (t *Tablo) detectFieldDelimiter(lines []string) rune {
+	if t.FieldDelimiter != 0 {
+		return t.FieldDelimiter
+	}
+
+	candidates := []rune{',', ';', '\t', '|'}
+	maxLines := min(len(lines), delimiterProbeLines)
+
+	for _, candidate := range candidates {
+		fieldCount := 0
+		matchedLines := 0
+
+		for i := 0; i < maxLines; i++ {
+			line := strings.TrimSpace(lines[i])
+			if line == "" {
+				continue
+			}
+
+			currentCount := countDelimiterOutsideQuotes(line, candidate) + 1
+			if currentCount <= 1 {
+				fieldCount = 0
+				break
+			}
+
+			if fieldCount == 0 {
+				fieldCount = currentCount
+			} else if fieldCount != currentCount {
+				fieldCount = 0
+				break
+			}
+
+			matchedLines++
+		}
+
+		if matchedLines >= 2 && fieldCount > 1 {
+			return candidate
+		}
+	}
+
+	return 0
+}
+
+func (t *Tablo) ensureDetectedFieldDelimiter(lines []string) {
+	if t.FieldDelimiter != 0 {
+		return
+	}
+
+	t.FieldDelimiter = t.detectFieldDelimiter(lines)
+}
+
 func (t *Tablo) selectColumnIndices(headers []string) []int {
 	if len(headers) == 0 || len(t.Args) == 0 {
 		return nil
@@ -206,24 +276,30 @@ func (t *Tablo) selectFields(fields []string, columnIndices []int) []string {
 
 func isHeaderLikeField(field string) bool {
 	field = strings.TrimSpace(field)
+	field = strings.Trim(field, `"'`)
+	field = strings.TrimLeft(field, "_-")
+	field = strings.TrimSpace(field)
 	if field == "" {
 		return false
 	}
 
-	for i, r := range field {
+	hasLetter := false
+	for _, r := range field {
 		switch {
-		case r == ' ' || r == '_' || r == '-':
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsDigit(r):
 			continue
-		case i == 0 && (r < 'A' || (r > 'Z' && r < 'a') || r > 'z'):
-			return false
-		case (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+		case unicode.IsSpace(r):
+			continue
+		case strings.ContainsRune("_-./():", r):
 			continue
 		default:
 			return false
 		}
 	}
 
-	return true
+	return hasLetter
 }
 
 func looksLikeHeader(fields []string) bool {
@@ -247,6 +323,8 @@ type jsonDataset struct {
 }
 
 func (t *Tablo) buildJSONDataset(lines []string) jsonDataset {
+	t.ensureDetectedFieldDelimiter(lines)
+
 	if len(lines) == 0 {
 		return jsonDataset{
 			rows: [][]string{},
@@ -527,6 +605,8 @@ func (t *Tablo) Tabelize() error {
 	if t.JSONOutput {
 		return t.renderJSON(lines)
 	}
+
+	t.ensureDetectedFieldDelimiter(lines)
 
 	drawBorders := !t.DrawBorder
 	drawSeparateRowsLine := !t.SeparateRows

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -34,7 +34,7 @@ const (
 	helpFieldDelimiterChar = "field delimiter char to split the line input"
 	helpNoSeparateRows     = "do not draw separation line under rows"
 	helpNoBorders          = "do not draw borders"
-	helpNoHeaders          = "hide headers line in filter by header result"
+	helpNoHeaders          = "hide the selected or detected header row"
 	helpFilterIndexes      = "filter columns by index"
 	helpJSONOutput         = "render output as json"
 
@@ -465,13 +465,29 @@ func (t *Tablo) processHeaders(tw table.Writer, lines []string) []int {
 
 func (t *Tablo) processRows(tw table.Writer, lines []string, columnIndices []int) {
 	for i, line := range lines {
-		if len(t.Args) > 0 && i == 0 {
+		if i == 0 && t.shouldSkipFirstRow(lines) {
 			continue
 		}
 		fields := t.splitFields(line)
 		selectedFields := t.selectFields(fields, columnIndices)
 		tw.AppendRow(stringSliceToRow(selectedFields))
 	}
+}
+
+func (t *Tablo) shouldSkipFirstRow(lines []string) bool {
+	if len(lines) == 0 {
+		return false
+	}
+
+	if len(t.Args) > 0 {
+		return true
+	}
+
+	if !t.HideHeaders {
+		return false
+	}
+
+	return looksLikeHeader(t.splitFields(lines[0]))
 }
 
 // Tabelize generates tablized output.

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -160,8 +160,8 @@ func (t *Tablo) detectFieldDelimiter(lines []string) rune {
 		matchedLines := 0
 
 		for i := 0; i < maxLines; i++ {
-			line := strings.TrimSpace(lines[i])
-			if line == "" {
+			line := lines[i]
+			if strings.TrimSpace(line) == "" {
 				continue
 			}
 

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -346,7 +346,7 @@ func (t *Tablo) buildJSONDataset(lines []string) jsonDataset {
 	}
 
 	start := 0
-	if dataset.hasHeader {
+	if dataset.hasHeader || t.shouldSkipFirstRow(lines) {
 		start = 1
 	}
 
@@ -555,6 +555,10 @@ func (t *Tablo) processRows(tw table.Writer, lines []string, columnIndices []int
 func (t *Tablo) shouldSkipFirstRow(lines []string) bool {
 	if len(lines) == 0 {
 		return false
+	}
+
+	if len(t.FilterIndexes) > 0 {
+		return t.HideHeaders && looksLikeHeader(t.splitFields(lines[0]))
 	}
 
 	if len(t.Args) > 0 {

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -643,6 +643,89 @@ superset-superset-worker
 	assert.Equal(t, expectedOutput, output.String())
 }
 
+func TestTablo_Tabelize_CSV_WithNoHeaders_SkipsDetectedHeaderRow(t *testing.T) {
+	input := bytes.NewBufferString(`Username;Identifier;First name;Last name
+booker12;9012;Rachel;Booker
+grey07;2070;Laura;Grey
+`)
+	output := new(BytesWriteCloser)
+
+	oldIsNamedPipe := tablo.IsNamedPipe
+	oldIsCharDevice := tablo.IsCharDevice
+	tablo.IsNamedPipe = func(_ os.FileInfo) bool { return true }
+	tablo.IsCharDevice = func(_ os.FileInfo) bool { return false }
+	defer func() {
+		tablo.IsNamedPipe = oldIsNamedPipe
+		tablo.IsCharDevice = oldIsCharDevice
+	}()
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter(";"),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithNoHeaders(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := `┌──────────┬──────┬────────┬────────┐
+│ booker12 │ 9012 │ Rachel │ Booker │
+├──────────┼──────┼────────┼────────┤
+│ grey07   │ 2070 │ Laura  │ Grey   │
+└──────────┴──────┴────────┴────────┘
+`
+	assert.Equal(t, expectedOutput, output.String())
+}
+
+func TestTablo_Tabelize_CSV_FilterIndexes_WithNoHeaders_SkipsDetectedHeaderRow(t *testing.T) {
+	input := bytes.NewBufferString(`Username;Identifier;First name;Last name
+booker12;9012;Rachel;Booker
+grey07;2070;Laura;Grey
+`)
+	output := new(BytesWriteCloser)
+
+	oldIsNamedPipe := tablo.IsNamedPipe
+	oldIsCharDevice := tablo.IsCharDevice
+	tablo.IsNamedPipe = func(_ os.FileInfo) bool { return true }
+	tablo.IsCharDevice = func(_ os.FileInfo) bool { return false }
+	defer func() {
+		tablo.IsNamedPipe = oldIsNamedPipe
+		tablo.IsCharDevice = oldIsCharDevice
+	}()
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter(";"),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithFilterIndexes("1,3"),
+		tablo.WithNoHeaders(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := `┌──────────┬────────┐
+│ booker12 │ Rachel │
+├──────────┼────────┤
+│ grey07   │ Laura  │
+└──────────┴────────┘
+`
+	assert.Equal(t, expectedOutput, output.String())
+}
+
 func TestTablo_Run_Returns_Error(t *testing.T) {
 	os.Args = []string{"tablo", "-l", ""}
 	resetFlags()

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -726,6 +726,87 @@ grey07;2070;Laura;Grey
 	assert.Equal(t, expectedOutput, output.String())
 }
 
+func TestTablo_Tabelize_CSV_WithQuotedUnicodeHeaders_AndNoHeaders_SkipsHeaderRow(t *testing.T) {
+	input := bytes.NewBufferString(`ID,"_ADI SOYADI","-T.C. KİMLİK NO",-BÖLÜM
+999721,"Filiz Yenilmez",23795235860,Muhasebe
+999722,"Ali Veli",12345678901,İnsan Kaynakları
+`)
+	output := new(BytesWriteCloser)
+
+	oldIsNamedPipe := tablo.IsNamedPipe
+	oldIsCharDevice := tablo.IsCharDevice
+	tablo.IsNamedPipe = func(_ os.FileInfo) bool { return true }
+	tablo.IsCharDevice = func(_ os.FileInfo) bool { return false }
+	defer func() {
+		tablo.IsNamedPipe = oldIsNamedPipe
+		tablo.IsCharDevice = oldIsCharDevice
+	}()
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter(","),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithNoHeaders(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := `┌────────┬──────────────────┬─────────────┬──────────────────┐
+│ 999721 │ "Filiz Yenilmez" │ 23795235860 │ Muhasebe         │
+├────────┼──────────────────┼─────────────┼──────────────────┤
+│ 999722 │ "Ali Veli"       │ 12345678901 │ İnsan Kaynakları │
+└────────┴──────────────────┴─────────────┴──────────────────┘
+`
+	assert.Equal(t, expectedOutput, output.String())
+}
+
+func TestTablo_Tabelize_CSV_AutoDetectsDelimiter_WithNoHeaders(t *testing.T) {
+	input := bytes.NewBufferString(`ID,"_ADI SOYADI","-T.C. KİMLİK NO",-BÖLÜM
+999721,"Filiz Yenilmez",23795235860,Muhasebe
+999722,"Ali Veli",12345678901,İnsan Kaynakları
+`)
+	output := new(BytesWriteCloser)
+
+	oldIsNamedPipe := tablo.IsNamedPipe
+	oldIsCharDevice := tablo.IsCharDevice
+	tablo.IsNamedPipe = func(_ os.FileInfo) bool { return true }
+	tablo.IsCharDevice = func(_ os.FileInfo) bool { return false }
+	defer func() {
+		tablo.IsNamedPipe = oldIsNamedPipe
+		tablo.IsCharDevice = oldIsCharDevice
+	}()
+
+	tbl, err := tablo.New(
+		tablo.WithOutputWriter(output),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithNoHeaders(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := `┌────────┬──────────────────┬─────────────┬──────────────────┐
+│ 999721 │ "Filiz Yenilmez" │ 23795235860 │ Muhasebe         │
+├────────┼──────────────────┼─────────────┼──────────────────┤
+│ 999722 │ "Ali Veli"       │ 12345678901 │ İnsan Kaynakları │
+└────────┴──────────────────┴─────────────┴──────────────────┘
+`
+	assert.Equal(t, expectedOutput, output.String())
+}
+
 func TestTablo_Run_Returns_Error(t *testing.T) {
 	os.Args = []string{"tablo", "-l", ""}
 	resetFlags()

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -489,6 +489,74 @@ func TestTablo_Tabelize_WithFieldDelimiter_Wrong_Column_Selection(t *testing.T) 
 	assert.Equal(t, expectedOutput, output.String())
 }
 
+func TestTablo_Tabelize_WithFieldDelimiter_Wrong_Column_Selection_WithNoHeaders(t *testing.T) {
+	input := bytes.NewBufferString("header1.header2\nfoo.bar\n")
+	output := new(BytesWriteCloser)
+
+	oldIsNamedPipe := tablo.IsNamedPipe
+	oldIsCharDevice := tablo.IsCharDevice
+	tablo.IsNamedPipe = func(_ os.FileInfo) bool { return true }
+	tablo.IsCharDevice = func(_ os.FileInfo) bool { return false }
+	defer func() {
+		tablo.IsNamedPipe = oldIsNamedPipe
+		tablo.IsCharDevice = oldIsCharDevice
+	}()
+
+	tbl, err := tablo.New(
+		tablo.WithArgs([]string{"xxx"}),
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter("."),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithNoHeaders(true),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := "┌─────┬─────┐\n│ foo │ bar │\n└─────┴─────┘\n"
+	assert.Equal(t, expectedOutput, output.String())
+}
+
+func TestTablo_Tabelize_FilterIndexesIgnoreArgsForHeaders(t *testing.T) {
+	input := bytes.NewBufferString("name|age\nvigo|42\n")
+	output := new(BytesWriteCloser)
+
+	oldIsNamedPipe := tablo.IsNamedPipe
+	oldIsCharDevice := tablo.IsCharDevice
+	tablo.IsNamedPipe = func(_ os.FileInfo) bool { return true }
+	tablo.IsCharDevice = func(_ os.FileInfo) bool { return false }
+	defer func() {
+		tablo.IsNamedPipe = oldIsNamedPipe
+		tablo.IsCharDevice = oldIsCharDevice
+	}()
+
+	tbl, err := tablo.New(
+		tablo.WithArgs([]string{"name"}),
+		tablo.WithOutputWriter(output),
+		tablo.WithFieldDelimiter("|"),
+		tablo.WithLineDelimiter("\n"),
+		tablo.WithFilterIndexes("2"),
+		tablo.WithReadInputFunc(func(_ io.Reader) (string, error) {
+			return input.String(), nil
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+
+	err = tbl.Tabelize()
+	assert.NoError(t, err)
+
+	expectedOutput := "┌─────┐\n│ age │\n├─────┤\n│ 42  │\n└─────┘\n"
+	assert.Equal(t, expectedOutput, output.String())
+}
+
 func TestTablo_Tabelize_Docker_Images(t *testing.T) {
 	input := bytes.NewBufferString(`REPOSITORY                         TAG       IMAGE ID       CREATED         SIZE
 superset-superset-worker-beat      latest    3292fc2e6758   2 weeks ago     958MB


### PR DESCRIPTION
## Summary
- skip detected header rows when `-nh` is used without header-name filtering
- cover CSV `-nh` behavior with regression tests, including `-fi` usage
- update help text and README examples to match the behavior