### PR TITLE
Add bash completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ usage: tablo [-flags] [COLUMN] [COLUMN] [COLUMN]
   flags:
 
   -version                          display version information (X.X.X)
-  --bash-completion                 print bash completion script
+  -bash-completion, --bash-completion
+                                    print bash completion script
   -f, -field-delimiter-char         field delimiter char to split the line input
                                     (omit for smart split: 2+ whitespace)
   -l, -line-delimiter-char          line delimiter char to split the input

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ usage: tablo [-flags] [COLUMN] [COLUMN] [COLUMN]
   flags:
 
   -version                          display version information (X.X.X)
+  --bash-completion                 print bash completion script
   -f, -field-delimiter-char         field delimiter char to split the line input
                                     (omit for smart split: 2+ whitespace)
   -l, -line-delimiter-char          line delimiter char to split the input
@@ -200,6 +201,30 @@ cat /etc/passwd | tablo -f ":" -n
 │ root                   │ * │ 0   │ 0   │ System Administrator                            │ /var/root                     │ /bin/sh          │
 └────────────────────────┴───┴─────┴─────┴─────────────────────────────────────────────────┴───────────────────────────────┴──────────────────┘
 # output is trimmed...
+```
+
+### Bash Completion
+
+Load completion into your current shell:
+
+```bash
+source <(tablo --bash-completion)
+```
+
+Or save it and load it from your shell profile:
+
+```bash
+tablo --bash-completion > ~/.tablo-completion.bash
+source ~/.tablo-completion.bash
+```
+
+The completion suggests flags, common delimiter values for `-f` / `-l`, file
+paths for the input/output arguments, and column names after you pass an input
+file:
+
+```bash
+tablo -f ";" ./users.csv <TAB>
+tablo -f ";" ./users.csv "First name" <TAB>
 ```
 
 If your input doesn’t have a kind of header, you can use `-fi` or `-filter-indexes`

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -15,6 +15,7 @@ import (
 const (
 	bashCompletionFlag = "--bash-completion"
 	completeFlag       = "--complete"
+	completionByteCap  = 64 * 1024
 )
 
 var (
@@ -221,6 +222,7 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 	}
 
 	current := currentCompletionWord(words, cword)
+	afterDoubleDash := completionAfterDoubleDash(words, cword)
 	if suggestions := completionInlineValueSuggestions(current); suggestions != nil {
 		return suggestions, nil
 	}
@@ -237,7 +239,7 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 		return nil, err
 	}
 
-	if strings.HasPrefix(current, "-") || current == "" && cword == 1 {
+	if !afterDoubleDash && (strings.HasPrefix(current, "-") || current == "" && cword == 1) {
 		return completionFlagMatches(current), nil
 	}
 	if state.filterIndexes || len(state.positionals) == 0 {
@@ -248,6 +250,16 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 	}
 
 	return completeColumnsFromFile(state, state.positionals[0], state.positionals[1:], current)
+}
+
+func completionAfterDoubleDash(words []string, cword int) bool {
+	for i := 1; i < cword && i < len(words); i++ {
+		if words[i] == "--" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func parseCompletionState(words []string, cword int, state *completionState) error {
@@ -461,6 +473,7 @@ func readCompletionLines(reader io.Reader, delimiter rune, limit int) ([]string,
 	buffered := bufio.NewReader(reader)
 	lines := make([]string, 0, limit)
 	var currentLine strings.Builder
+	bytesRead := 0
 
 	flushLine := func() {
 		line := currentLine.String()
@@ -480,6 +493,13 @@ func readCompletionLines(reader io.Reader, delimiter rune, limit int) ([]string,
 		r, _, err := buffered.ReadRune()
 		switch err {
 		case nil:
+			bytesRead += utf8.RuneLen(r)
+			if bytesRead > completionByteCap {
+				if currentLine.Len() > 0 {
+					flushLine()
+				}
+				return lines, nil
+			}
 			if r == delimiter {
 				flushLine()
 				continue

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -1,6 +1,7 @@
 package tablo
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,7 @@ const (
 
 var (
 	completionBooleanFlags = map[string]struct{}{
+		bashCompletionFlag:   {},
 		"-version":           {},
 		"--version":          {},
 		"-n":                 {},
@@ -47,6 +49,7 @@ var (
 		"--output":               {},
 	}
 	completionAllFlags = []string{
+		bashCompletionFlag,
 		"-version",
 		"--version",
 		"-f",
@@ -86,7 +89,7 @@ type completionState struct {
 func bashCompletionScript(binaryName string) string {
 	functionName := sanitizeCompletionFunctionName(binaryName)
 
-	return fmt.Sprintf(`_%[1]s_completion() {
+	return fmt.Sprintf(`_%[2]s_completion() {
     local cur prev word expect_value positional_count
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -342,7 +345,12 @@ func sanitizeCompletionFunctionName(name string) string {
 		return "tablo"
 	}
 
-	return b.String()
+	sanitized := b.String()
+	if first := rune(sanitized[0]); unicode.IsDigit(first) {
+		return "_" + sanitized
+	}
+
+	return sanitized
 }
 
 func completeColumnsFromFile(state completionState, path string, selected []string, current string) ([]string, error) {
@@ -352,32 +360,20 @@ func completeColumnsFromFile(state completionState, path string, selected []stri
 	}
 	defer func() { _ = file.Close() }()
 
-	input, err := readInput(file)
+	lines, err := readCompletionLines(file, state.lineDelimiter, delimiterProbeLines)
 	if err != nil {
 		return nil, err
 	}
-
-	lines := strings.FieldsFunc(input, func(r rune) bool {
-		return r == state.lineDelimiter
-	})
-
-	filteredLines := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-		filteredLines = append(filteredLines, line)
-	}
-	if len(filteredLines) == 0 {
+	if len(lines) == 0 {
 		return nil, nil
 	}
 
 	tbl := &Tablo{
 		FieldDelimiter: state.fieldDelimiter,
 	}
-	tbl.ensureDetectedFieldDelimiter(filteredLines)
+	tbl.ensureDetectedFieldDelimiter(lines)
 
-	headers := tbl.splitFields(filteredLines[0])
+	headers := tbl.splitFields(lines[0])
 	seen := make(map[string]struct{}, len(selected))
 	for _, column := range selected {
 		seen[strings.ToLower(column)] = struct{}{}
@@ -394,4 +390,46 @@ func completeColumnsFromFile(state completionState, path string, selected []stri
 	}
 
 	return suggestions, nil
+}
+
+func readCompletionLines(reader io.Reader, delimiter rune, limit int) ([]string, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	buffered := bufio.NewReader(reader)
+	lines := make([]string, 0, limit)
+	var currentLine strings.Builder
+
+	flushLine := func() {
+		line := currentLine.String()
+		currentLine.Reset()
+
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			return
+		}
+
+		lines = append(lines, line)
+	}
+
+	for len(lines) < limit {
+		r, _, err := buffered.ReadRune()
+		switch err {
+		case nil:
+			if r == delimiter {
+				flushLine()
+				continue
+			}
+			currentLine.WriteRune(r)
+		case io.EOF:
+			if currentLine.Len() > 0 {
+				flushLine()
+			}
+			return lines, nil
+		default:
+			return nil, fmt.Errorf(errorWrapFormat, err)
+		}
+	}
+
+	return lines, nil
 }

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -98,7 +98,7 @@ func bashCompletionScript(binaryName string) string {
 	quotedBinaryName := shellQuote(binaryName)
 
 	return fmt.Sprintf(`_%[1]s_completion() {
-    local cur prev word expect_value positional_count reply prefix value
+    local cur prev word expect_value positional_count reply prefix value i
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev=""
@@ -465,6 +465,9 @@ func readCompletionLines(reader io.Reader, delimiter rune, limit int) ([]string,
 	flushLine := func() {
 		line := currentLine.String()
 		currentLine.Reset()
+		if delimiter == '\n' {
+			line = strings.TrimSuffix(line, "\r")
+		}
 
 		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
 			return

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -20,42 +20,58 @@ var (
 		"-version":           {},
 		"--version":          {},
 		"-n":                 {},
+		"-no-separate-rows":  {},
 		"--no-separate-rows": {},
 		"-nb":                {},
+		"-no-borders":        {},
 		"--no-borders":       {},
 		"-nh":                {},
+		"-no-headers":        {},
 		"--no-headers":       {},
 		"-j":                 {},
+		"-json":              {},
 		"--json":             {},
 	}
 	completionValueFlags = map[string]struct{}{
 		"-f":                     {},
+		"-field-delimiter-char":  {},
 		"--field-delimiter-char": {},
 		"-l":                     {},
+		"-line-delimiter-char":   {},
 		"--line-delimiter-char":  {},
 		"-fi":                    {},
+		"-filter-indexes":        {},
 		"--filter-indexes":       {},
 		"-o":                     {},
+		"-output":                {},
 		"--output":               {},
 	}
 	completionAllFlags = []string{
 		"-version",
 		"--version",
 		"-f",
+		"-field-delimiter-char",
 		"--field-delimiter-char",
 		"-l",
+		"-line-delimiter-char",
 		"--line-delimiter-char",
 		"-n",
+		"-no-separate-rows",
 		"--no-separate-rows",
 		"-nb",
+		"-no-borders",
 		"--no-borders",
 		"-nh",
+		"-no-headers",
 		"--no-headers",
 		"-fi",
+		"-filter-indexes",
 		"--filter-indexes",
 		"-j",
+		"-json",
 		"--json",
 		"-o",
+		"-output",
 		"--output",
 	}
 )
@@ -71,28 +87,67 @@ func bashCompletionScript(binaryName string) string {
 	functionName := sanitizeCompletionFunctionName(binaryName)
 
 	return fmt.Sprintf(`_%[1]s_completion() {
-    local cur prev
+    local cur prev word expect_value positional_count
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev=""
+    expect_value=0
+    positional_count=0
     if (( COMP_CWORD > 0 )); then
         prev="${COMP_WORDS[COMP_CWORD-1]}"
     fi
 
     case "${prev}" in
-        -o|--output)
+        -o|-output|--output)
             compopt -o default
             COMPREPLY=( $(compgen -f -- "${cur}") )
             return 0
             ;;
     esac
 
+    for (( i=1; i<COMP_CWORD; i++ )); do
+        word="${COMP_WORDS[i]}"
+
+        if (( expect_value == 1 )); then
+            expect_value=0
+            continue
+        fi
+
+        case "${word}" in
+            -f|-field-delimiter-char|--field-delimiter-char|\
+            -l|-line-delimiter-char|--line-delimiter-char|\
+            -fi|-filter-indexes|--filter-indexes|\
+            -o|-output|--output)
+                expect_value=1
+                continue
+                ;;
+            -field-delimiter-char=*|--field-delimiter-char=*|\
+            -line-delimiter-char=*|--line-delimiter-char=*|\
+            -filter-indexes=*|--filter-indexes=*|\
+            -output=*|--output=*)
+                continue
+                ;;
+            -version|--version|\
+            -n|-no-separate-rows|--no-separate-rows|\
+            -nb|-no-borders|--no-borders|\
+            -nh|-no-headers|--no-headers|\
+            -j|-json|--json)
+                continue
+                ;;
+            -*)
+                continue
+                ;;
+        esac
+
+        positional_count=$(( positional_count + 1 ))
+    done
+
     mapfile -t COMPREPLY < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[3]s -- "${COMP_WORDS[@]}")
     if (( ${#COMPREPLY[@]} > 0 )); then
         return 0
     fi
 
-    if (( COMP_CWORD == 1 )); then
+    if (( positional_count == 0 )) && [[ "${cur}" != -* ]]; then
         compopt -o default
         COMPREPLY=( $(compgen -f -- "${cur}") )
     fi
@@ -212,24 +267,24 @@ func completionHasValueFlag(flagName string) bool {
 
 func applyCompletionFlagValue(state *completionState, flagName, value string) {
 	switch flagName {
-	case "-f", "--field-delimiter-char":
+	case "-f", "-field-delimiter-char", "--field-delimiter-char":
 		if value != "" {
 			state.fieldDelimiter = parseSpecialChars(value)
 		}
-	case "-l", "--line-delimiter-char":
+	case "-l", "-line-delimiter-char", "--line-delimiter-char":
 		if value != "" {
 			state.lineDelimiter = parseSpecialChars(value)
 		}
-	case "-fi", "--filter-indexes":
+	case "-fi", "-filter-indexes", "--filter-indexes":
 		state.filterIndexes = value != ""
 	}
 }
 
 func completionValueSuggestions(flagName, current string) []string {
 	switch flagName {
-	case "-f", "--field-delimiter-char":
+	case "-f", "-field-delimiter-char", "--field-delimiter-char":
 		return completionPrefixMatches([]string{",", ";", "|", ":", "\\t", " "}, current)
-	case "-l", "--line-delimiter-char":
+	case "-l", "-line-delimiter-char", "--line-delimiter-char":
 		return completionPrefixMatches([]string{"\\n", "\\t", "\\r", ":", ";", "|"}, current)
 	default:
 		return nil

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -96,7 +97,7 @@ func bashCompletionScript(binaryName string) string {
 	functionName := sanitizeCompletionFunctionName(binaryName)
 	quotedBinaryName := shellQuote(binaryName)
 
-	return fmt.Sprintf(`_%[2]s_completion() {
+	return fmt.Sprintf(`_%[1]s_completion() {
     local cur prev word expect_value positional_count reply prefix value
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -167,7 +168,7 @@ func bashCompletionScript(binaryName string) string {
 
     while IFS= read -r reply; do
         COMPREPLY+=("${reply}")
-    done < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[3]s -- "${COMP_WORDS[@]}")
+    done < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[2]s -- "${COMP_WORDS[@]}")
 
     if (( ${#COMPREPLY[@]} > 0 )); then
         return 0
@@ -180,8 +181,8 @@ func bashCompletionScript(binaryName string) string {
     fi
 }
 
-complete -F _%[2]s_completion -- %[4]s
-`, binaryName, functionName, completeFlag, quotedBinaryName)
+complete -F _%[1]s_completion -- %[3]s
+`, functionName, completeFlag, quotedBinaryName)
 }
 
 func runCompletion(words []string, output io.Writer) error {
@@ -401,7 +402,8 @@ func sanitizeCompletionFunctionName(name string) string {
 	}
 
 	sanitized := b.String()
-	if first := rune(sanitized[0]); unicode.IsDigit(first) {
+	first, _ := utf8.DecodeRuneInString(sanitized)
+	if unicode.IsDigit(first) {
 		return "_" + sanitized
 	}
 

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -19,6 +19,9 @@ const (
 var (
 	completionBooleanFlags = map[string]struct{}{
 		bashCompletionFlag:   {},
+		"-h":                 {},
+		"-help":              {},
+		"--help":             {},
 		"-version":           {},
 		"--version":          {},
 		"-n":                 {},
@@ -50,6 +53,9 @@ var (
 	}
 	completionAllFlags = []string{
 		bashCompletionFlag,
+		"-h",
+		"-help",
+		"--help",
 		"-version",
 		"--version",
 		"-f",
@@ -91,7 +97,7 @@ func bashCompletionScript(binaryName string) string {
 	quotedBinaryName := shellQuote(binaryName)
 
 	return fmt.Sprintf(`_%[2]s_completion() {
-    local cur prev word expect_value positional_count reply
+    local cur prev word expect_value positional_count reply prefix value
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev=""
@@ -106,6 +112,17 @@ func bashCompletionScript(binaryName string) string {
             while IFS= read -r reply; do
                 COMPREPLY+=("${reply}")
             done < <(compgen -f -- "${cur}")
+            return 0
+            ;;
+    esac
+
+    case "${cur}" in
+        -o=*|-output=*|--output=*)
+            prefix="${cur%%=*}="
+            value="${cur#*=}"
+            while IFS= read -r reply; do
+                COMPREPLY+=("${prefix}${reply}")
+            done < <(compgen -f -- "${value}")
             return 0
             ;;
     esac
@@ -132,6 +149,7 @@ func bashCompletionScript(binaryName string) string {
             -output=*|--output=*)
                 continue
                 ;;
+            -h|-help|--help|\
             -version|--version|\
             -n|-no-separate-rows|--no-separate-rows|\
             -nb|-no-borders|--no-borders|\
@@ -202,6 +220,10 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 	}
 
 	current := currentCompletionWord(words, cword)
+	if suggestions := completionInlineValueSuggestions(current); suggestions != nil {
+		return suggestions, nil
+	}
+
 	previous := words[cword-1]
 	if suggestions := completionValueSuggestions(previous, current); suggestions != nil {
 		return suggestions, nil
@@ -296,7 +318,7 @@ func applyCompletionFlagValue(state *completionState, flagName, value string) {
 func completionValueSuggestions(flagName, current string) []string {
 	switch flagName {
 	case "-f", "-field-delimiter-char", "--field-delimiter-char":
-		return completionPrefixMatches([]string{",", ";", "|", ":", "\\t", " "}, current)
+		return completionPrefixMatches([]string{",", ";", "|", ":", "\\t"}, current)
 	case "-l", "-line-delimiter-char", "--line-delimiter-char":
 		return completionPrefixMatches([]string{"\\n", "\\t", "\\r", ":", ";", "|"}, current)
 	default:
@@ -306,6 +328,29 @@ func completionValueSuggestions(flagName, current string) []string {
 
 func completionFlagMatches(current string) []string {
 	return completionPrefixMatches(completionAllFlags, current)
+}
+
+func completionInlineValueSuggestions(current string) []string {
+	flagName, currentValue, hasInlineValue := completionFlagToken(current)
+	if !hasInlineValue {
+		return nil
+	}
+
+	if flagName == "-o" || flagName == "-output" || flagName == "--output" {
+		return nil
+	}
+
+	suggestions := completionValueSuggestions(flagName, currentValue)
+	if suggestions == nil {
+		return nil
+	}
+
+	prefixed := make([]string, 0, len(suggestions))
+	for _, suggestion := range suggestions {
+		prefixed = append(prefixed, flagName+"="+suggestion)
+	}
+
+	return prefixed
 }
 
 func completionPrefixMatches(candidates []string, current string) []string {

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -13,31 +13,33 @@ import (
 )
 
 const (
-	bashCompletionFlag = "--bash-completion"
-	completeFlag       = "--complete"
-	completionByteCap  = 64 * 1024
+	shortBashCompletionFlag = "-bash-completion"
+	bashCompletionFlag      = "--bash-completion"
+	completeFlag            = "--complete"
+	completionByteCap       = 64 * 1024
 )
 
 var (
 	completionBooleanFlags = map[string]struct{}{
-		bashCompletionFlag:   {},
-		"-h":                 {},
-		"-help":              {},
-		"--help":             {},
-		"-version":           {},
-		"--version":          {},
-		"-n":                 {},
-		"-no-separate-rows":  {},
-		"--no-separate-rows": {},
-		"-nb":                {},
-		"-no-borders":        {},
-		"--no-borders":       {},
-		"-nh":                {},
-		"-no-headers":        {},
-		"--no-headers":       {},
-		"-j":                 {},
-		"-json":              {},
-		"--json":             {},
+		shortBashCompletionFlag: {},
+		bashCompletionFlag:      {},
+		"-h":                    {},
+		"-help":                 {},
+		"--help":                {},
+		"-version":              {},
+		"--version":             {},
+		"-n":                    {},
+		"-no-separate-rows":     {},
+		"--no-separate-rows":    {},
+		"-nb":                   {},
+		"-no-borders":           {},
+		"--no-borders":          {},
+		"-nh":                   {},
+		"-no-headers":           {},
+		"--no-headers":          {},
+		"-j":                    {},
+		"-json":                 {},
+		"--json":                {},
 	}
 	completionValueFlags = map[string]struct{}{
 		"-f":                     {},
@@ -54,6 +56,7 @@ var (
 		"--output":               {},
 	}
 	completionAllFlags = []string{
+		shortBashCompletionFlag,
 		bashCompletionFlag,
 		"-h",
 		"-help",
@@ -99,35 +102,16 @@ func bashCompletionScript(binaryName string) string {
 	quotedBinaryName := shellQuote(binaryName)
 
 	return fmt.Sprintf(`_%[1]s_completion() {
-    local cur prev word expect_value positional_count reply prefix value i
+    local cur prev word expect_value positional_count reply prefix value saw_double_dash i
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev=""
     expect_value=0
     positional_count=0
+    saw_double_dash=0
     if (( COMP_CWORD > 0 )); then
         prev="${COMP_WORDS[COMP_CWORD-1]}"
     fi
-
-    case "${prev}" in
-        -o|-output|--output)
-            while IFS= read -r reply; do
-                COMPREPLY+=("${reply}")
-            done < <(compgen -f -- "${cur}")
-            return 0
-            ;;
-    esac
-
-    case "${cur}" in
-        -o=*|-output=*|--output=*)
-            prefix="${cur%%=*}="
-            value="${cur#*=}"
-            while IFS= read -r reply; do
-                COMPREPLY+=("${prefix}${reply}")
-            done < <(compgen -f -- "${value}")
-            return 0
-            ;;
-    esac
 
     for (( i=1; i<COMP_CWORD; i++ )); do
         word="${COMP_WORDS[i]}"
@@ -136,8 +120,16 @@ func bashCompletionScript(binaryName string) string {
             expect_value=0
             continue
         fi
+        if (( saw_double_dash == 1 )); then
+            positional_count=$(( positional_count + 1 ))
+            continue
+        fi
 
         case "${word}" in
+            --)
+                saw_double_dash=1
+                continue
+                ;;
             -f|-field-delimiter-char|--field-delimiter-char|\
             -l|-line-delimiter-char|--line-delimiter-char|\
             -fi|-filter-indexes|--filter-indexes|\
@@ -167,6 +159,28 @@ func bashCompletionScript(binaryName string) string {
         positional_count=$(( positional_count + 1 ))
     done
 
+    if (( saw_double_dash == 0 )); then
+        case "${prev}" in
+            -o|-output|--output)
+                while IFS= read -r reply; do
+                    COMPREPLY+=("${reply}")
+                done < <(compgen -f -- "${cur}")
+                return 0
+                ;;
+        esac
+
+        case "${cur}" in
+            -o=*|-output=*|--output=*)
+                prefix="${cur%%=*}="
+                value="${cur#*=}"
+                while IFS= read -r reply; do
+                    COMPREPLY+=("${prefix}${reply}")
+                done < <(compgen -f -- "${value}")
+                return 0
+                ;;
+        esac
+    fi
+
     while IFS= read -r reply; do
         COMPREPLY+=("${reply}")
     done < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[2]s -- "${COMP_WORDS[@]}")
@@ -175,7 +189,15 @@ func bashCompletionScript(binaryName string) string {
         return 0
     fi
 
-    if (( positional_count == 0 )) && [[ "${cur}" != -* ]]; then
+    case "${prev}" in
+        -f|-field-delimiter-char|--field-delimiter-char|\
+        -l|-line-delimiter-char|--line-delimiter-char|\
+        -fi|-filter-indexes|--filter-indexes)
+            return 0
+            ;;
+    esac
+
+    if (( positional_count == 0 )) && { [[ "${cur}" != -* ]] || (( saw_double_dash == 1 )); }; then
         while IFS= read -r reply; do
             COMPREPLY+=("${reply}")
         done < <(compgen -f -- "${cur}")
@@ -223,13 +245,15 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 
 	current := currentCompletionWord(words, cword)
 	afterDoubleDash := completionAfterDoubleDash(words, cword)
-	if suggestions := completionInlineValueSuggestions(current); suggestions != nil {
-		return suggestions, nil
-	}
+	if !afterDoubleDash {
+		if suggestions := completionInlineValueSuggestions(current); suggestions != nil {
+			return suggestions, nil
+		}
 
-	previous := words[cword-1]
-	if suggestions := completionValueSuggestions(previous, current); suggestions != nil {
-		return suggestions, nil
+		previous := words[cword-1]
+		if suggestions := completionValueSuggestions(previous, current); suggestions != nil {
+			return suggestions, nil
+		}
 	}
 
 	state := completionState{
@@ -490,10 +514,10 @@ func readCompletionLines(reader io.Reader, delimiter rune, limit int) ([]string,
 	}
 
 	for len(lines) < limit {
-		r, _, err := buffered.ReadRune()
+		r, size, err := buffered.ReadRune()
 		switch err {
 		case nil:
-			bytesRead += utf8.RuneLen(r)
+			bytesRead += size
 			if bytesRead > completionByteCap {
 				if currentLine.Len() > 0 {
 					flushLine()

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -88,9 +88,10 @@ type completionState struct {
 
 func bashCompletionScript(binaryName string) string {
 	functionName := sanitizeCompletionFunctionName(binaryName)
+	quotedBinaryName := shellQuote(binaryName)
 
 	return fmt.Sprintf(`_%[2]s_completion() {
-    local cur prev word expect_value positional_count
+    local cur prev word expect_value positional_count reply
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev=""
@@ -102,8 +103,9 @@ func bashCompletionScript(binaryName string) string {
 
     case "${prev}" in
         -o|-output|--output)
-            compopt -o default
-            COMPREPLY=( $(compgen -f -- "${cur}") )
+            while IFS= read -r reply; do
+                COMPREPLY+=("${reply}")
+            done < <(compgen -f -- "${cur}")
             return 0
             ;;
     esac
@@ -145,19 +147,23 @@ func bashCompletionScript(binaryName string) string {
         positional_count=$(( positional_count + 1 ))
     done
 
-    mapfile -t COMPREPLY < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[3]s -- "${COMP_WORDS[@]}")
+    while IFS= read -r reply; do
+        COMPREPLY+=("${reply}")
+    done < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[3]s -- "${COMP_WORDS[@]}")
+
     if (( ${#COMPREPLY[@]} > 0 )); then
         return 0
     fi
 
     if (( positional_count == 0 )) && [[ "${cur}" != -* ]]; then
-        compopt -o default
-        COMPREPLY=( $(compgen -f -- "${cur}") )
+        while IFS= read -r reply; do
+            COMPREPLY+=("${reply}")
+        done < <(compgen -f -- "${cur}")
     fi
 }
 
-complete -F _%[2]s_completion %[1]s
-`, binaryName, functionName, completeFlag)
+complete -F _%[2]s_completion -- %[4]s
+`, binaryName, functionName, completeFlag, quotedBinaryName)
 }
 
 func runCompletion(words []string, output io.Writer) error {
@@ -230,6 +236,10 @@ func parseCompletionState(words []string, cword int, state *completionState) err
 			applyCompletionFlagValue(state, expectingValue, token)
 			expectingValue = ""
 			continue
+		}
+		if token == "--" {
+			state.positionals = append(state.positionals, words[i+1:cword]...)
+			break
 		}
 
 		flagName, flagValue, hasInlineValue := completionFlagToken(token)
@@ -351,6 +361,10 @@ func sanitizeCompletionFunctionName(name string) string {
 	}
 
 	return sanitized
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
 func completeColumnsFromFile(state completionState, path string, selected []string, current string) ([]string, error) {

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -263,7 +263,9 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 		return nil, err
 	}
 
-	if !afterDoubleDash && (strings.HasPrefix(current, "-") || current == "" && cword == 1) {
+	if !afterDoubleDash &&
+		len(state.positionals) == 0 &&
+		(strings.HasPrefix(current, "-") || current == "" && cword == 1) {
 		return completionFlagMatches(current), nil
 	}
 	if state.filterIndexes || len(state.positionals) == 0 {

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -271,11 +271,15 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 	if state.filterIndexes || len(state.positionals) == 0 {
 		return nil, nil
 	}
-	if !isRegularFile(state.positionals[0]) {
+	resolvedPath, err := resolveCompletionPath(state.positionals[0])
+	if err != nil {
+		return nil, err
+	}
+	if !isRegularFile(resolvedPath) {
 		return nil, nil
 	}
 
-	return completeColumnsFromFile(state, state.positionals[0], state.positionals[1:], current)
+	return completeColumnsFromFile(state, resolvedPath, state.positionals[1:], current)
 }
 
 func completionAfterDoubleDash(words []string, cword int) bool {
@@ -453,7 +457,12 @@ func shellQuote(value string) string {
 }
 
 func completeColumnsFromFile(state completionState, path string, selected []string, current string) ([]string, error) {
-	file, err := os.Open(filepath.Clean(path))
+	resolvedPath, err := resolveCompletionPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(filepath.Clean(resolvedPath))
 	if err != nil {
 		return nil, fmt.Errorf(errorWrapFormat, err)
 	}
@@ -473,6 +482,10 @@ func completeColumnsFromFile(state completionState, path string, selected []stri
 	tbl.ensureDetectedFieldDelimiter(lines)
 
 	headers := tbl.splitFields(lines[0])
+	if !looksLikeHeader(headers) {
+		return nil, nil
+	}
+
 	seen := make(map[string]struct{}, len(selected))
 	for _, column := range selected {
 		seen[strings.ToLower(column)] = struct{}{}
@@ -489,6 +502,32 @@ func completeColumnsFromFile(state completionState, path string, selected []stri
 	}
 
 	return suggestions, nil
+}
+
+func resolveCompletionPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	expanded := os.ExpandEnv(path)
+	if expanded == "~" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf(errorWrapFormat, err)
+		}
+
+		return homeDir, nil
+	}
+	if strings.HasPrefix(expanded, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf(errorWrapFormat, err)
+		}
+
+		return filepath.Join(homeDir, strings.TrimPrefix(expanded, "~/")), nil
+	}
+
+	return expanded, nil
 }
 
 func readCompletionLines(reader io.Reader, delimiter rune, limit int) ([]string, error) {

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -120,7 +120,7 @@ func bashCompletionScript(binaryName string) string {
             expect_value=0
             continue
         fi
-        if (( saw_double_dash == 1 )); then
+        if (( saw_double_dash == 1 )) || (( positional_count > 0 )); then
             positional_count=$(( positional_count + 1 ))
             continue
         fi
@@ -152,6 +152,7 @@ func bashCompletionScript(binaryName string) string {
                 continue
                 ;;
             -*)
+                positional_count=$(( positional_count + 1 ))
                 continue
                 ;;
         esac
@@ -184,6 +185,12 @@ func bashCompletionScript(binaryName string) string {
     while IFS= read -r reply; do
         COMPREPLY+=("${reply}")
     done < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[2]s -- "${COMP_WORDS[@]}")
+
+    if (( positional_count == 0 )) && [[ "${cur}" == -* ]]; then
+        while IFS= read -r reply; do
+            COMPREPLY+=("${reply}")
+        done < <(compgen -f -- "${cur}")
+    fi
 
     if (( ${#COMPREPLY[@]} > 0 )); then
         return 0
@@ -245,7 +252,13 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 
 	current := currentCompletionWord(words, cword)
 	afterDoubleDash := completionAfterDoubleDash(words, cword)
-	if !afterDoubleDash {
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+	if err := parseCompletionState(words, cword, &state); err != nil {
+		return nil, err
+	}
+	if !afterDoubleDash && len(state.positionals) == 0 {
 		if suggestions := completionInlineValueSuggestions(current); suggestions != nil {
 			return suggestions, nil
 		}
@@ -254,13 +267,6 @@ func completionSuggestions(words []string, cword int) ([]string, error) {
 		if suggestions := completionValueSuggestions(previous, current); suggestions != nil {
 			return suggestions, nil
 		}
-	}
-
-	state := completionState{
-		lineDelimiter: defaultLineDelimiter,
-	}
-	if err := parseCompletionState(words, cword, &state); err != nil {
-		return nil, err
 	}
 
 	if !afterDoubleDash &&
@@ -304,6 +310,10 @@ func parseCompletionState(words []string, cword int, state *completionState) err
 		}
 		if token == "--" {
 			state.positionals = append(state.positionals, words[i+1:cword]...)
+			break
+		}
+		if len(state.positionals) > 0 {
+			state.positionals = append(state.positionals, words[i:cword]...)
 			break
 		}
 

--- a/internal/tablo/completion.go
+++ b/internal/tablo/completion.go
@@ -1,0 +1,342 @@
+package tablo
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	bashCompletionFlag = "--bash-completion"
+	completeFlag       = "--complete"
+)
+
+var (
+	completionBooleanFlags = map[string]struct{}{
+		"-version":           {},
+		"--version":          {},
+		"-n":                 {},
+		"--no-separate-rows": {},
+		"-nb":                {},
+		"--no-borders":       {},
+		"-nh":                {},
+		"--no-headers":       {},
+		"-j":                 {},
+		"--json":             {},
+	}
+	completionValueFlags = map[string]struct{}{
+		"-f":                     {},
+		"--field-delimiter-char": {},
+		"-l":                     {},
+		"--line-delimiter-char":  {},
+		"-fi":                    {},
+		"--filter-indexes":       {},
+		"-o":                     {},
+		"--output":               {},
+	}
+	completionAllFlags = []string{
+		"-version",
+		"--version",
+		"-f",
+		"--field-delimiter-char",
+		"-l",
+		"--line-delimiter-char",
+		"-n",
+		"--no-separate-rows",
+		"-nb",
+		"--no-borders",
+		"-nh",
+		"--no-headers",
+		"-fi",
+		"--filter-indexes",
+		"-j",
+		"--json",
+		"-o",
+		"--output",
+	}
+)
+
+type completionState struct {
+	fieldDelimiter rune
+	lineDelimiter  rune
+	filterIndexes  bool
+	positionals    []string
+}
+
+func bashCompletionScript(binaryName string) string {
+	functionName := sanitizeCompletionFunctionName(binaryName)
+
+	return fmt.Sprintf(`_%[1]s_completion() {
+    local cur prev
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev=""
+    if (( COMP_CWORD > 0 )); then
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+    fi
+
+    case "${prev}" in
+        -o|--output)
+            compopt -o default
+            COMPREPLY=( $(compgen -f -- "${cur}") )
+            return 0
+            ;;
+    esac
+
+    mapfile -t COMPREPLY < <(COMP_CWORD="${COMP_CWORD}" "${COMP_WORDS[0]}" %[3]s -- "${COMP_WORDS[@]}")
+    if (( ${#COMPREPLY[@]} > 0 )); then
+        return 0
+    fi
+
+    if (( COMP_CWORD == 1 )); then
+        compopt -o default
+        COMPREPLY=( $(compgen -f -- "${cur}") )
+    fi
+}
+
+complete -F _%[2]s_completion %[1]s
+`, binaryName, functionName, completeFlag)
+}
+
+func runCompletion(words []string, output io.Writer) error {
+	if len(words) > 0 && words[0] == "--" {
+		words = words[1:]
+	}
+	if len(words) == 0 {
+		return nil
+	}
+
+	cword, err := strconv.Atoi(os.Getenv("COMP_CWORD"))
+	if err != nil || cword < 0 {
+		cword = len(words) - 1
+	}
+	if cword >= len(words) {
+		cword = len(words) - 1
+	}
+
+	suggestions, err := completionSuggestions(words, cword)
+	if err != nil {
+		return err
+	}
+
+	for _, suggestion := range suggestions {
+		if _, err := fmt.Fprintln(output, suggestion); err != nil {
+			return fmt.Errorf(errorWrapFormat, err)
+		}
+	}
+
+	return nil
+}
+
+func completionSuggestions(words []string, cword int) ([]string, error) {
+	if len(words) == 0 || cword <= 0 {
+		return completionFlagMatches(currentCompletionWord(words, cword)), nil
+	}
+
+	current := currentCompletionWord(words, cword)
+	previous := words[cword-1]
+	if suggestions := completionValueSuggestions(previous, current); suggestions != nil {
+		return suggestions, nil
+	}
+
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+	if err := parseCompletionState(words, cword, &state); err != nil {
+		return nil, err
+	}
+
+	if strings.HasPrefix(current, "-") || current == "" && cword == 1 {
+		return completionFlagMatches(current), nil
+	}
+	if state.filterIndexes || len(state.positionals) == 0 {
+		return nil, nil
+	}
+	if !isRegularFile(state.positionals[0]) {
+		return nil, nil
+	}
+
+	return completeColumnsFromFile(state, state.positionals[0], state.positionals[1:], current)
+}
+
+func parseCompletionState(words []string, cword int, state *completionState) error {
+	expectingValue := ""
+
+	for i := 1; i < cword; i++ {
+		token := words[i]
+		if expectingValue != "" {
+			applyCompletionFlagValue(state, expectingValue, token)
+			expectingValue = ""
+			continue
+		}
+
+		flagName, flagValue, hasInlineValue := completionFlagToken(token)
+		switch {
+		case completionHasValueFlag(flagName):
+			if hasInlineValue {
+				applyCompletionFlagValue(state, flagName, flagValue)
+			} else {
+				expectingValue = flagName
+			}
+		case completionHasBooleanFlag(flagName):
+			continue
+		default:
+			state.positionals = append(state.positionals, token)
+		}
+	}
+
+	return nil
+}
+
+func completionFlagToken(token string) (flagName, flagValue string, hasInlineValue bool) {
+	if head, tail, ok := strings.Cut(token, "="); ok {
+		return head, tail, true
+	}
+
+	return token, "", false
+}
+
+func completionHasBooleanFlag(flagName string) bool {
+	_, ok := completionBooleanFlags[flagName]
+	return ok
+}
+
+func completionHasValueFlag(flagName string) bool {
+	_, ok := completionValueFlags[flagName]
+	return ok
+}
+
+func applyCompletionFlagValue(state *completionState, flagName, value string) {
+	switch flagName {
+	case "-f", "--field-delimiter-char":
+		if value != "" {
+			state.fieldDelimiter = parseSpecialChars(value)
+		}
+	case "-l", "--line-delimiter-char":
+		if value != "" {
+			state.lineDelimiter = parseSpecialChars(value)
+		}
+	case "-fi", "--filter-indexes":
+		state.filterIndexes = value != ""
+	}
+}
+
+func completionValueSuggestions(flagName, current string) []string {
+	switch flagName {
+	case "-f", "--field-delimiter-char":
+		return completionPrefixMatches([]string{",", ";", "|", ":", "\\t", " "}, current)
+	case "-l", "--line-delimiter-char":
+		return completionPrefixMatches([]string{"\\n", "\\t", "\\r", ":", ";", "|"}, current)
+	default:
+		return nil
+	}
+}
+
+func completionFlagMatches(current string) []string {
+	return completionPrefixMatches(completionAllFlags, current)
+}
+
+func completionPrefixMatches(candidates []string, current string) []string {
+	if current == "" {
+		return append([]string(nil), candidates...)
+	}
+
+	var suggestions []string
+	for _, candidate := range candidates {
+		if strings.HasPrefix(strings.ToLower(candidate), strings.ToLower(current)) {
+			suggestions = append(suggestions, candidate)
+		}
+	}
+
+	return suggestions
+}
+
+func currentCompletionWord(words []string, cword int) string {
+	if cword >= 0 && cword < len(words) {
+		return words[cword]
+	}
+
+	return ""
+}
+
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return info.Mode().IsRegular()
+}
+
+func sanitizeCompletionFunctionName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+
+	if b.Len() == 0 {
+		return "tablo"
+	}
+
+	return b.String()
+}
+
+func completeColumnsFromFile(state completionState, path string, selected []string, current string) ([]string, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf(errorWrapFormat, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	input, err := readInput(file)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.FieldsFunc(input, func(r rune) bool {
+		return r == state.lineDelimiter
+	})
+
+	filteredLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		filteredLines = append(filteredLines, line)
+	}
+	if len(filteredLines) == 0 {
+		return nil, nil
+	}
+
+	tbl := &Tablo{
+		FieldDelimiter: state.fieldDelimiter,
+	}
+	tbl.ensureDetectedFieldDelimiter(filteredLines)
+
+	headers := tbl.splitFields(filteredLines[0])
+	seen := make(map[string]struct{}, len(selected))
+	for _, column := range selected {
+		seen[strings.ToLower(column)] = struct{}{}
+	}
+
+	var suggestions []string
+	for _, header := range headers {
+		if _, ok := seen[strings.ToLower(header)]; ok {
+			continue
+		}
+		if current == "" || strings.HasPrefix(strings.ToLower(header), strings.ToLower(current)) {
+			suggestions = append(suggestions, header)
+		}
+	}
+
+	return suggestions, nil
+}

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -29,6 +29,10 @@ func TestBashCompletionScript(t *testing.T) {
 	assert.Contains(t, script, "complete -F _tablo_completion -- 'tablo'")
 	assert.Contains(t, script, completeFlag)
 	assert.Contains(t, script, "positional_count=0")
+	assert.Contains(t, script, "saw_double_dash=0")
+	assert.Contains(t, script, "if (( saw_double_dash == 0 )); then")
+	assert.Contains(t, script, "if (( saw_double_dash == 1 )); then")
+	assert.Contains(t, script, "-fi|-filter-indexes|--filter-indexes")
 	assert.Contains(t, script, "-field-delimiter-char")
 	assert.Contains(t, script, "-o=*|-output=*|--output=*")
 	assert.NotContains(t, script, "mapfile")
@@ -65,6 +69,7 @@ func TestCompletionSuggestions_AllFlagsForFirstArgument(t *testing.T) {
 	suggestions, err := completionSuggestions([]string{"tablo", ""}, 1)
 
 	require.NoError(t, err)
+	assert.Contains(t, suggestions, shortBashCompletionFlag)
 	assert.Contains(t, suggestions, bashCompletionFlag)
 	assert.Contains(t, suggestions, "-h")
 	assert.Contains(t, suggestions, "--help")
@@ -129,6 +134,20 @@ func TestCompletionSuggestions_NoColumnCompletionWhenFirstPositionalIsNotFile(t 
 
 func TestCompletionSuggestions_AfterDoubleDashDoesNotSuggestFlags(t *testing.T) {
 	suggestions, err := completionSuggestions([]string{"tablo", "--", "-weird.csv"}, 2)
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
+}
+
+func TestCompletionSuggestions_AfterDoubleDashDoesNotSuggestFlagValues(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "--", "-f"}, 2)
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
+}
+
+func TestCompletionSuggestions_AfterDoubleDashDoesNotSuggestInlineFlagValues(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "--", "--field-delimiter-char=:"}, 2)
 
 	require.NoError(t, err)
 	assert.Nil(t, suggestions)

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -2,6 +2,9 @@ package tablo
 
 import (
 	"bytes"
+	"errors"
+	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingWriter struct {
+	err error
+}
+
+func (f failingWriter) Write([]byte) (int, error) {
+	return 0, f.err
+}
 
 func TestBashCompletionScript(t *testing.T) {
 	script := bashCompletionScript("tablo")
@@ -20,6 +31,7 @@ func TestBashCompletionScript(t *testing.T) {
 
 func TestSanitizeCompletionFunctionName(t *testing.T) {
 	assert.Equal(t, "tablo_dev", sanitizeCompletionFunctionName("tablo-dev"))
+	assert.Equal(t, "tablo", sanitizeCompletionFunctionName(""))
 }
 
 func TestCompletionSuggestions_Flags(t *testing.T) {
@@ -29,11 +41,45 @@ func TestCompletionSuggestions_Flags(t *testing.T) {
 	assert.Equal(t, []string{"--json"}, suggestions)
 }
 
+func TestCompletionSuggestions_AllFlagsForFirstArgument(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", ""}, 1)
+
+	require.NoError(t, err)
+	assert.Contains(t, suggestions, "--output")
+	assert.Contains(t, suggestions, "-f")
+}
+
 func TestCompletionSuggestions_FieldDelimiterValues(t *testing.T) {
 	suggestions, err := completionSuggestions([]string{"tablo", "-f", ":"}, 2)
 
 	require.NoError(t, err)
 	assert.Contains(t, suggestions, ":")
+}
+
+func TestCompletionSuggestions_LineDelimiterValues(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "-l", "\\r"}, 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"\\r"}, suggestions)
+}
+
+func TestCompletionSuggestions_NoColumnCompletionWhenFilterIndexesSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completionSuggestions([]string{"tablo", "-fi", "1,2", inputFile, ""}, 4)
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
+}
+
+func TestCompletionSuggestions_NoColumnCompletionWhenFirstPositionalIsNotFile(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "Username"}, 1)
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
 }
 
 func TestCompletionSuggestions_ColumnsFromInputFile(t *testing.T) {
@@ -48,6 +94,18 @@ func TestCompletionSuggestions_ColumnsFromInputFile(t *testing.T) {
 	assert.Equal(t, []string{"First name"}, suggestions)
 }
 
+func TestCompletionSuggestions_ColumnsFromInputFile_AutoDetectDelimiter(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username,Identifier,First name\nbooker12,9012,Rachel\n"), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completionSuggestions([]string{"tablo", inputFile, "Id"}, 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Identifier"}, suggestions)
+}
+
 func TestCompletionSuggestions_ColumnsExcludeAlreadySelected(t *testing.T) {
 	tmpDir := t.TempDir()
 	inputFile := filepath.Join(tmpDir, "users.csv")
@@ -58,6 +116,15 @@ func TestCompletionSuggestions_ColumnsExcludeAlreadySelected(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"Identifier", "First name"}, suggestions)
+}
+
+func TestRunCompletion_NoWords(t *testing.T) {
+	var output bytes.Buffer
+
+	err := runCompletion(nil, &output)
+
+	require.NoError(t, err)
+	assert.Empty(t, output.String())
 }
 
 func TestRunCompletion_WritesSuggestions(t *testing.T) {
@@ -73,4 +140,131 @@ func TestRunCompletion_WritesSuggestions(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "Username", strings.TrimSpace(output.String()))
+}
+
+func TestRunCompletion_InvalidCompCwordFallsBack(t *testing.T) {
+	t.Setenv("COMP_CWORD", "invalid")
+
+	var output bytes.Buffer
+	err := runCompletion([]string{"--", "tablo", "--j"}, &output)
+
+	require.NoError(t, err)
+	assert.Equal(t, "--json", strings.TrimSpace(output.String()))
+}
+
+func TestRunCompletion_ReturnsWriteError(t *testing.T) {
+	writeErr := errors.New("write failed")
+	t.Setenv("COMP_CWORD", "2")
+
+	err := runCompletion([]string{"--", "tablo", "--j"}, failingWriter{err: writeErr})
+
+	assert.ErrorIs(t, err, writeErr)
+}
+
+func TestParseCompletionState(t *testing.T) {
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+
+	err := parseCompletionState([]string{"tablo", "--field-delimiter-char=;", "-l", "\\t", "-fi", "1,2", "--json", "users.csv", "Username"}, 8, &state)
+
+	require.NoError(t, err)
+	assert.Equal(t, ';', state.fieldDelimiter)
+	assert.Equal(t, '\t', state.lineDelimiter)
+	assert.True(t, state.filterIndexes)
+	assert.Equal(t, []string{"users.csv"}, state.positionals)
+}
+
+func TestCompletionFlagToken(t *testing.T) {
+	flagName, flagValue, hasInlineValue := completionFlagToken("--output=file.txt")
+	assert.Equal(t, "--output", flagName)
+	assert.Equal(t, "file.txt", flagValue)
+	assert.True(t, hasInlineValue)
+
+	flagName, flagValue, hasInlineValue = completionFlagToken("--json")
+	assert.Equal(t, "--json", flagName)
+	assert.Empty(t, flagValue)
+	assert.False(t, hasInlineValue)
+}
+
+func TestApplyCompletionFlagValue(t *testing.T) {
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+
+	applyCompletionFlagValue(&state, "--line-delimiter-char", "\\r")
+	applyCompletionFlagValue(&state, "--field-delimiter-char", "|")
+	applyCompletionFlagValue(&state, "--filter-indexes", "1")
+	applyCompletionFlagValue(&state, "--filter-indexes", "")
+
+	assert.Equal(t, '\r', state.lineDelimiter)
+	assert.Equal(t, '|', state.fieldDelimiter)
+	assert.False(t, state.filterIndexes)
+}
+
+func TestCompletionValueSuggestions_UnknownFlag(t *testing.T) {
+	assert.Nil(t, completionValueSuggestions("--unknown", ""))
+}
+
+func TestCompletionPrefixMatches(t *testing.T) {
+	assert.Equal(t, []string{"--json"}, completionPrefixMatches([]string{"--json", "--output"}, "--J"))
+	assert.Equal(t, []string{"a", "b"}, completionPrefixMatches([]string{"a", "b"}, ""))
+}
+
+func TestCurrentCompletionWord_OutOfRange(t *testing.T) {
+	assert.Empty(t, currentCompletionWord([]string{"tablo"}, 4))
+}
+
+func TestIsRegularFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username\n"), 0o600)
+	require.NoError(t, err)
+
+	assert.True(t, isRegularFile(inputFile))
+	assert.False(t, isRegularFile(tmpDir))
+	assert.False(t, isRegularFile(filepath.Join(tmpDir, "missing.csv")))
+}
+
+func TestCompleteColumnsFromFile_CommentOnlyInput(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("# comment\n"), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completeColumnsFromFile(completionState{lineDelimiter: '\n'}, inputFile, nil, "")
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
+}
+
+func TestCompleteColumnsFromFile_OpenError(t *testing.T) {
+	_, err := completeColumnsFromFile(completionState{lineDelimiter: '\n'}, "/does/not/exist.csv", nil, "")
+
+	assert.Error(t, err)
+}
+
+func TestRun_CompleteFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("COMP_CWORD", "4")
+	os.Args = []string{"tablo", "--complete", "--", "tablo", "-f", ";", inputFile, "Us"}
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	err = Run()
+	require.NoError(t, err)
+	_ = w.Close()
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "Username\n", string(output))
 }

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -30,6 +30,7 @@ func TestBashCompletionScript(t *testing.T) {
 	assert.Contains(t, script, completeFlag)
 	assert.Contains(t, script, "positional_count=0")
 	assert.Contains(t, script, "-field-delimiter-char")
+	assert.Contains(t, script, "-o=*|-output=*|--output=*")
 	assert.NotContains(t, script, "mapfile")
 	assert.NotContains(t, script, "compopt")
 }
@@ -65,6 +66,8 @@ func TestCompletionSuggestions_AllFlagsForFirstArgument(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, suggestions, bashCompletionFlag)
+	assert.Contains(t, suggestions, "-h")
+	assert.Contains(t, suggestions, "--help")
 	assert.Contains(t, suggestions, "--output")
 	assert.Contains(t, suggestions, "-f")
 }
@@ -74,6 +77,7 @@ func TestCompletionSuggestions_FieldDelimiterValues(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, suggestions, ":")
+	assert.NotContains(t, suggestions, " ")
 }
 
 func TestCompletionSuggestions_LineDelimiterValues(t *testing.T) {
@@ -88,6 +92,20 @@ func TestCompletionSuggestions_LongFieldDelimiterValues(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{":"}, suggestions)
+}
+
+func TestCompletionSuggestions_InlineFieldDelimiterValues(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "--field-delimiter-char=:"}, 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--field-delimiter-char=:"}, suggestions)
+}
+
+func TestCompletionSuggestions_InlineLineDelimiterValues(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "--line-delimiter-char=\\r"}, 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--line-delimiter-char=\\r"}, suggestions)
 }
 
 func TestCompletionSuggestions_NoColumnCompletionWhenFilterIndexesSet(t *testing.T) {
@@ -270,6 +288,16 @@ func TestApplyCompletionFlagValue_SingleDashLongFlags(t *testing.T) {
 
 func TestCompletionValueSuggestions_UnknownFlag(t *testing.T) {
 	assert.Nil(t, completionValueSuggestions("--unknown", ""))
+}
+
+func TestCompletionInlineValueSuggestions(t *testing.T) {
+	assert.Equal(
+		t,
+		[]string{"--field-delimiter-char=:"},
+		completionInlineValueSuggestions("--field-delimiter-char=:"),
+	)
+	assert.Nil(t, completionInlineValueSuggestions("--output=foo"))
+	assert.Nil(t, completionInlineValueSuggestions("--json"))
 }
 
 func TestCompletionPrefixMatches(t *testing.T) {

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -1,0 +1,76 @@
+package tablo
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBashCompletionScript(t *testing.T) {
+	script := bashCompletionScript("tablo")
+
+	assert.Contains(t, script, "complete -F _tablo_completion tablo")
+	assert.Contains(t, script, completeFlag)
+}
+
+func TestSanitizeCompletionFunctionName(t *testing.T) {
+	assert.Equal(t, "tablo_dev", sanitizeCompletionFunctionName("tablo-dev"))
+}
+
+func TestCompletionSuggestions_Flags(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "--j"}, 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--json"}, suggestions)
+}
+
+func TestCompletionSuggestions_FieldDelimiterValues(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "-f", ":"}, 2)
+
+	require.NoError(t, err)
+	assert.Contains(t, suggestions, ":")
+}
+
+func TestCompletionSuggestions_ColumnsFromInputFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username;Identifier;First name\nbooker12;9012;Rachel\n"), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completionSuggestions([]string{"tablo", "-f", ";", inputFile, "Fi"}, 4)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"First name"}, suggestions)
+}
+
+func TestCompletionSuggestions_ColumnsExcludeAlreadySelected(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username;Identifier;First name\nbooker12;9012;Rachel\n"), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completionSuggestions([]string{"tablo", "-f", ";", inputFile, "Username", ""}, 5)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Identifier", "First name"}, suggestions)
+}
+
+func TestRunCompletion_WritesSuggestions(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("COMP_CWORD", "4")
+
+	var output bytes.Buffer
+	err = runCompletion([]string{"--", "tablo", "-f", ";", inputFile, "Us"}, &output)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Username", strings.TrimSpace(output.String()))
+}

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -26,10 +26,12 @@ func TestBashCompletionScript(t *testing.T) {
 	script := bashCompletionScript("tablo")
 
 	assert.Contains(t, script, "_tablo_completion() {")
-	assert.Contains(t, script, "complete -F _tablo_completion tablo")
+	assert.Contains(t, script, "complete -F _tablo_completion -- 'tablo'")
 	assert.Contains(t, script, completeFlag)
 	assert.Contains(t, script, "positional_count=0")
 	assert.Contains(t, script, "-field-delimiter-char")
+	assert.NotContains(t, script, "mapfile")
+	assert.NotContains(t, script, "compopt")
 }
 
 func TestSanitizeCompletionFunctionName(t *testing.T) {
@@ -42,8 +44,13 @@ func TestBashCompletionScript_UsesSanitizedFunctionName(t *testing.T) {
 	script := bashCompletionScript("tablo-dev")
 
 	assert.Contains(t, script, "_tablo_dev_completion() {")
-	assert.Contains(t, script, "complete -F _tablo_dev_completion tablo-dev")
+	assert.Contains(t, script, "complete -F _tablo_dev_completion -- 'tablo-dev'")
 	assert.NotContains(t, script, "_tablo-dev_completion() {")
+}
+
+func TestShellQuote(t *testing.T) {
+	assert.Equal(t, "'tablo dev'", shellQuote("tablo dev"))
+	assert.Equal(t, `'tablo'\''dev'`, shellQuote("tablo'dev"))
 }
 
 func TestCompletionSuggestions_Flags(t *testing.T) {
@@ -207,6 +214,17 @@ func TestParseCompletionState_SingleDashLongFlags(t *testing.T) {
 	assert.Equal(t, '\t', state.lineDelimiter)
 	assert.True(t, state.filterIndexes)
 	assert.Empty(t, state.positionals)
+}
+
+func TestParseCompletionState_EndOfFlags(t *testing.T) {
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+
+	err := parseCompletionState([]string{"tablo", "--", "users.csv", "Username"}, 4, &state)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"users.csv", "Username"}, state.positionals)
 }
 
 func TestCompletionFlagToken(t *testing.T) {

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -25,6 +25,7 @@ func (f failingWriter) Write([]byte) (int, error) {
 func TestBashCompletionScript(t *testing.T) {
 	script := bashCompletionScript("tablo")
 
+	assert.Contains(t, script, "_tablo_completion() {")
 	assert.Contains(t, script, "complete -F _tablo_completion tablo")
 	assert.Contains(t, script, completeFlag)
 	assert.Contains(t, script, "positional_count=0")
@@ -33,7 +34,16 @@ func TestBashCompletionScript(t *testing.T) {
 
 func TestSanitizeCompletionFunctionName(t *testing.T) {
 	assert.Equal(t, "tablo_dev", sanitizeCompletionFunctionName("tablo-dev"))
+	assert.Equal(t, "_1tablo", sanitizeCompletionFunctionName("1tablo"))
 	assert.Equal(t, "tablo", sanitizeCompletionFunctionName(""))
+}
+
+func TestBashCompletionScript_UsesSanitizedFunctionName(t *testing.T) {
+	script := bashCompletionScript("tablo-dev")
+
+	assert.Contains(t, script, "_tablo_dev_completion() {")
+	assert.Contains(t, script, "complete -F _tablo_dev_completion tablo-dev")
+	assert.NotContains(t, script, "_tablo-dev_completion() {")
 }
 
 func TestCompletionSuggestions_Flags(t *testing.T) {
@@ -47,6 +57,7 @@ func TestCompletionSuggestions_AllFlagsForFirstArgument(t *testing.T) {
 	suggestions, err := completionSuggestions([]string{"tablo", ""}, 1)
 
 	require.NoError(t, err)
+	assert.Contains(t, suggestions, bashCompletionFlag)
 	assert.Contains(t, suggestions, "--output")
 	assert.Contains(t, suggestions, "-f")
 }
@@ -273,6 +284,35 @@ func TestCompleteColumnsFromFile_CommentOnlyInput(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Nil(t, suggestions)
+}
+
+func TestCompleteColumnsFromFile_ReadsOnlyHeaderProbeLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	content := strings.Join([]string{
+		"# comment",
+		"",
+		"Username,Identifier,First name",
+		"booker12,9012,Rachel",
+		"grey07,2070,Laura",
+		"johnson81,4081,Craig",
+		"jenkins46,9346,Mary",
+		"smith79,5079,Jamie",
+	}, "\n")
+	err := os.WriteFile(inputFile, []byte(content), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completeColumnsFromFile(completionState{lineDelimiter: '\n'}, inputFile, nil, "Fi")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"First name"}, suggestions)
+}
+
+func TestReadCompletionLines(t *testing.T) {
+	lines, err := readCompletionLines(strings.NewReader("# comment\n\nname,age\nvigo,42\nignored,after\n"), '\n', 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"name,age", "vigo,42"}, lines)
 }
 
 func TestCompleteColumnsFromFile_OpenError(t *testing.T) {

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -58,6 +58,21 @@ func TestShellQuote(t *testing.T) {
 	assert.Equal(t, `'tablo'\''dev'`, shellQuote("tablo'dev"))
 }
 
+func TestResolveCompletionPath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	t.Setenv("TABLO_TEST_DIR", "tablo")
+
+	path, err := resolveCompletionPath("~/data.csv")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(homeDir, "data.csv"), path)
+
+	path, err = resolveCompletionPath("$TABLO_TEST_DIR/data.csv")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("tablo", "data.csv"), path)
+}
+
 func TestCompletionSuggestions_Flags(t *testing.T) {
 	suggestions, err := completionSuggestions([]string{"tablo", "--j"}, 1)
 
@@ -141,6 +156,18 @@ func TestCompletionSuggestions_AfterDoubleDashDoesNotSuggestFlags(t *testing.T) 
 
 func TestCompletionSuggestions_AfterDoubleDashDoesNotSuggestFlagValues(t *testing.T) {
 	suggestions, err := completionSuggestions([]string{"tablo", "--", "-f"}, 2)
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
+}
+
+func TestCompletionSuggestions_AfterPositionalDoesNotSuggestFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completionSuggestions([]string{"tablo", inputFile, "-n"}, 2)
 
 	require.NoError(t, err)
 	assert.Nil(t, suggestions)
@@ -378,6 +405,43 @@ func TestCompleteColumnsFromFile_ReadsOnlyHeaderProbeLines(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"First name"}, suggestions)
+}
+
+func TestCompleteColumnsFromFile_WithoutHeaderReturnsNoSuggestions(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	content := strings.Join([]string{
+		"booker12;9012;Rachel",
+		"grey07;2070;Laura",
+	}, "\n")
+	err := os.WriteFile(inputFile, []byte(content), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completeColumnsFromFile(completionState{
+		lineDelimiter:  '\n',
+		fieldDelimiter: ';',
+	}, inputFile, nil, "Ra")
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
+}
+
+func TestCompleteColumnsFromFile_ResolvesHomePath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	inputFile := filepath.Join(homeDir, "tablo-completion-home.csv")
+	err = os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(inputFile) }()
+
+	suggestions, err := completeColumnsFromFile(completionState{
+		lineDelimiter:  '\n',
+		fieldDelimiter: ';',
+	}, "~/tablo-completion-home.csv", nil, "Us")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Username"}, suggestions)
 }
 
 func TestReadCompletionLines(t *testing.T) {

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -27,6 +27,8 @@ func TestBashCompletionScript(t *testing.T) {
 
 	assert.Contains(t, script, "complete -F _tablo_completion tablo")
 	assert.Contains(t, script, completeFlag)
+	assert.Contains(t, script, "positional_count=0")
+	assert.Contains(t, script, "-field-delimiter-char")
 }
 
 func TestSanitizeCompletionFunctionName(t *testing.T) {
@@ -61,6 +63,13 @@ func TestCompletionSuggestions_LineDelimiterValues(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"\\r"}, suggestions)
+}
+
+func TestCompletionSuggestions_LongFieldDelimiterValues(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "-field-delimiter-char", ":"}, 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{":"}, suggestions)
 }
 
 func TestCompletionSuggestions_NoColumnCompletionWhenFilterIndexesSet(t *testing.T) {
@@ -175,6 +184,20 @@ func TestParseCompletionState(t *testing.T) {
 	assert.Equal(t, []string{"users.csv"}, state.positionals)
 }
 
+func TestParseCompletionState_SingleDashLongFlags(t *testing.T) {
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+
+	err := parseCompletionState([]string{"tablo", "-field-delimiter-char=;", "-line-delimiter-char", "\\t", "-filter-indexes", "1,2", "-json", "users.csv"}, 7, &state)
+
+	require.NoError(t, err)
+	assert.Equal(t, ';', state.fieldDelimiter)
+	assert.Equal(t, '\t', state.lineDelimiter)
+	assert.True(t, state.filterIndexes)
+	assert.Empty(t, state.positionals)
+}
+
 func TestCompletionFlagToken(t *testing.T) {
 	flagName, flagValue, hasInlineValue := completionFlagToken("--output=file.txt")
 	assert.Equal(t, "--output", flagName)
@@ -200,6 +223,20 @@ func TestApplyCompletionFlagValue(t *testing.T) {
 	assert.Equal(t, '\r', state.lineDelimiter)
 	assert.Equal(t, '|', state.fieldDelimiter)
 	assert.False(t, state.filterIndexes)
+}
+
+func TestApplyCompletionFlagValue_SingleDashLongFlags(t *testing.T) {
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+
+	applyCompletionFlagValue(&state, "-line-delimiter-char", "\\r")
+	applyCompletionFlagValue(&state, "-field-delimiter-char", ";")
+	applyCompletionFlagValue(&state, "-filter-indexes", "2")
+
+	assert.Equal(t, '\r', state.lineDelimiter)
+	assert.Equal(t, ';', state.fieldDelimiter)
+	assert.True(t, state.filterIndexes)
 }
 
 func TestCompletionValueSuggestions_UnknownFlag(t *testing.T) {

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -127,6 +127,13 @@ func TestCompletionSuggestions_NoColumnCompletionWhenFirstPositionalIsNotFile(t 
 	assert.Nil(t, suggestions)
 }
 
+func TestCompletionSuggestions_AfterDoubleDashDoesNotSuggestFlags(t *testing.T) {
+	suggestions, err := completionSuggestions([]string{"tablo", "--", "-weird.csv"}, 2)
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
+}
+
 func TestCompletionSuggestions_ColumnsFromInputFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	inputFile := filepath.Join(tmpDir, "users.csv")
@@ -359,6 +366,16 @@ func TestReadCompletionLines(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"name,age", "vigo,42"}, lines)
+}
+
+func TestReadCompletionLines_StopsAtByteCap(t *testing.T) {
+	veryLong := strings.Repeat("a", completionByteCap+10)
+
+	lines, err := readCompletionLines(strings.NewReader(veryLong), '\n', 2)
+
+	require.NoError(t, err)
+	require.Len(t, lines, 1)
+	assert.Len(t, lines[0], completionByteCap)
 }
 
 func TestCompleteColumnsFromFile_OpenError(t *testing.T) {

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -374,6 +374,12 @@ func TestRun_CompleteFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Setenv("COMP_CWORD", "4")
+	oldArgs := os.Args
+	oldFlagSet := flag.CommandLine
+	defer func() {
+		os.Args = oldArgs
+		flag.CommandLine = oldFlagSet
+	}()
 	os.Args = []string{"tablo", "--complete", "--", "tablo", "-f", ";", inputFile, "Us"}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 

--- a/internal/tablo/completion_internal_test.go
+++ b/internal/tablo/completion_internal_test.go
@@ -31,7 +31,9 @@ func TestBashCompletionScript(t *testing.T) {
 	assert.Contains(t, script, "positional_count=0")
 	assert.Contains(t, script, "saw_double_dash=0")
 	assert.Contains(t, script, "if (( saw_double_dash == 0 )); then")
-	assert.Contains(t, script, "if (( saw_double_dash == 1 )); then")
+	assert.Contains(t, script, "if (( saw_double_dash == 1 )) || (( positional_count > 0 )); then")
+	assert.Contains(t, script, "if (( positional_count == 0 )) && [[ \"${cur}\" == -* ]]; then")
+	assert.Contains(t, script, "-*)")
 	assert.Contains(t, script, "-fi|-filter-indexes|--filter-indexes")
 	assert.Contains(t, script, "-field-delimiter-char")
 	assert.Contains(t, script, "-o=*|-output=*|--output=*")
@@ -126,6 +128,18 @@ func TestCompletionSuggestions_InlineLineDelimiterValues(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"--line-delimiter-char=\\r"}, suggestions)
+}
+
+func TestCompletionSuggestions_AfterPositionalDoesNotSuggestInlineFlagValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.csv")
+	err := os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
+	require.NoError(t, err)
+
+	suggestions, err := completionSuggestions([]string{"tablo", inputFile, "--field-delimiter-char=:"}, 2)
+
+	require.NoError(t, err)
+	assert.Nil(t, suggestions)
 }
 
 func TestCompletionSuggestions_NoColumnCompletionWhenFilterIndexesSet(t *testing.T) {
@@ -298,6 +312,17 @@ func TestParseCompletionState_EndOfFlags(t *testing.T) {
 	assert.Equal(t, []string{"users.csv", "Username"}, state.positionals)
 }
 
+func TestParseCompletionState_StopsAtFirstPositional(t *testing.T) {
+	state := completionState{
+		lineDelimiter: defaultLineDelimiter,
+	}
+
+	err := parseCompletionState([]string{"tablo", "users.csv", "-o", "out.txt"}, 4, &state)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"users.csv", "-o", "out.txt"}, state.positionals)
+}
+
 func TestCompletionFlagToken(t *testing.T) {
 	flagName, flagValue, hasInlineValue := completionFlagToken("--output=file.txt")
 	assert.Equal(t, "--output", flagName)
@@ -427,13 +452,12 @@ func TestCompleteColumnsFromFile_WithoutHeaderReturnsNoSuggestions(t *testing.T)
 }
 
 func TestCompleteColumnsFromFile_ResolvesHomePath(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	require.NoError(t, err)
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
 
 	inputFile := filepath.Join(homeDir, "tablo-completion-home.csv")
-	err = os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
+	err := os.WriteFile(inputFile, []byte("Username;Identifier\nbooker12;9012\n"), 0o600)
 	require.NoError(t, err)
-	defer func() { _ = os.Remove(inputFile) }()
 
 	suggestions, err := completeColumnsFromFile(completionState{
 		lineDelimiter:  '\n',

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -812,6 +812,20 @@ func New(options ...Option) (*Tablo, error) {
 
 // Run runs the command.
 func Run() error {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case bashCompletionFlag:
+			_, err := fmt.Fprint(os.Stdout, bashCompletionScript(filepath.Base(os.Args[0])))
+			if err != nil {
+				return fmt.Errorf(errorWrapFormat, err)
+			}
+
+			return nil
+		case completeFlag:
+			return runCompletion(os.Args[2:], os.Stdout)
+		}
+	}
+
 	flag.Usage = showUsage
 	flag.CommandLine.Usage = showUsage
 

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -814,6 +814,9 @@ func New(options ...Option) (*Tablo, error) {
 func Run() error {
 	if len(os.Args) > 1 {
 		for i, arg := range os.Args[1:] {
+			if arg == "--" {
+				break
+			}
 			switch arg {
 			case bashCompletionFlag:
 				_, err := fmt.Fprint(os.Stdout, bashCompletionScript(filepath.Base(os.Args[0])))

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -813,8 +813,23 @@ func New(options ...Option) (*Tablo, error) {
 // Run runs the command.
 func Run() error {
 	if len(os.Args) > 1 {
+		skipNext := false
 		for i, arg := range os.Args[1:] {
+			if skipNext {
+				skipNext = false
+				continue
+			}
 			if arg == "--" {
+				break
+			}
+			flagName, _, hasInlineValue := completionFlagToken(arg)
+			if completionHasValueFlag(flagName) {
+				if !hasInlineValue {
+					skipNext = true
+				}
+				continue
+			}
+			if !strings.HasPrefix(arg, "-") || arg == "-" {
 				break
 			}
 			switch arg {

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -818,7 +818,7 @@ func Run() error {
 				break
 			}
 			switch arg {
-			case bashCompletionFlag:
+			case shortBashCompletionFlag, bashCompletionFlag:
 				_, err := fmt.Fprint(os.Stdout, bashCompletionScript(filepath.Base(os.Args[0])))
 				if err != nil {
 					return fmt.Errorf(errorWrapFormat, err)

--- a/internal/tablo/tablo.go
+++ b/internal/tablo/tablo.go
@@ -813,16 +813,18 @@ func New(options ...Option) (*Tablo, error) {
 // Run runs the command.
 func Run() error {
 	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case bashCompletionFlag:
-			_, err := fmt.Fprint(os.Stdout, bashCompletionScript(filepath.Base(os.Args[0])))
-			if err != nil {
-				return fmt.Errorf(errorWrapFormat, err)
-			}
+		for i, arg := range os.Args[1:] {
+			switch arg {
+			case bashCompletionFlag:
+				_, err := fmt.Fprint(os.Stdout, bashCompletionScript(filepath.Base(os.Args[0])))
+				if err != nil {
+					return fmt.Errorf(errorWrapFormat, err)
+				}
 
-			return nil
-		case completeFlag:
-			return runCompletion(os.Args[2:], os.Stdout)
+				return nil
+			case completeFlag:
+				return runCompletion(os.Args[i+2:], os.Stdout)
+			}
 		}
 	}
 

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -1417,6 +1417,6 @@ func TestRun_PrintBashCompletion(t *testing.T) {
 	output := new(BytesWriteCloser)
 	_, _ = output.ReadFrom(r)
 
-	assert.Contains(t, output.String(), "complete -F _tablo_completion tablo")
+	assert.Contains(t, output.String(), "complete -F _tablo_completion -- 'tablo'")
 	assert.Contains(t, output.String(), "--complete")
 }

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -1397,6 +1397,7 @@ func TestRun_ShowUsage_WithHelpFlag(t *testing.T) {
 	assert.ErrorIs(t, err, flag.ErrHelp)
 	assert.Contains(t, buf.String(), "usage:")
 	assert.Contains(t, buf.String(), "tablo")
+	assert.Contains(t, buf.String(), "-bash-completion")
 	assert.Contains(t, buf.String(), "--bash-completion")
 }
 
@@ -1423,6 +1424,26 @@ func TestRun_PrintBashCompletion(t *testing.T) {
 
 func TestRun_PrintBashCompletion_AfterOtherFlags(t *testing.T) {
 	os.Args = []string{"tablo", "-n", "--bash-completion"}
+	resetFlags()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	err = tablo.Run()
+	assert.NoError(t, err)
+	_ = w.Close()
+
+	output := new(BytesWriteCloser)
+	_, _ = output.ReadFrom(r)
+
+	assert.Contains(t, output.String(), "complete -F _tablo_completion -- 'tablo'")
+}
+
+func TestRun_PrintBashCompletion_ShortLongFlag(t *testing.T) {
+	os.Args = []string{"tablo", "-bash-completion"}
 	resetFlags()
 
 	oldStdout := os.Stdout

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -1420,3 +1420,23 @@ func TestRun_PrintBashCompletion(t *testing.T) {
 	assert.Contains(t, output.String(), "complete -F _tablo_completion -- 'tablo'")
 	assert.Contains(t, output.String(), "--complete")
 }
+
+func TestRun_PrintBashCompletion_AfterOtherFlags(t *testing.T) {
+	os.Args = []string{"tablo", "-n", "--bash-completion"}
+	resetFlags()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	err = tablo.Run()
+	assert.NoError(t, err)
+	_ = w.Close()
+
+	output := new(BytesWriteCloser)
+	_, _ = output.ReadFrom(r)
+
+	assert.Contains(t, output.String(), "complete -F _tablo_completion -- 'tablo'")
+}

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -1397,4 +1397,26 @@ func TestRun_ShowUsage_WithHelpFlag(t *testing.T) {
 	assert.ErrorIs(t, err, flag.ErrHelp)
 	assert.Contains(t, buf.String(), "usage:")
 	assert.Contains(t, buf.String(), "tablo")
+	assert.Contains(t, buf.String(), "--bash-completion")
+}
+
+func TestRun_PrintBashCompletion(t *testing.T) {
+	os.Args = []string{"tablo", "--bash-completion"}
+	resetFlags()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	err = tablo.Run()
+	assert.NoError(t, err)
+	_ = w.Close()
+
+	output := new(BytesWriteCloser)
+	_, _ = output.ReadFrom(r)
+
+	assert.Contains(t, output.String(), "complete -F _tablo_completion tablo")
+	assert.Contains(t, output.String(), "--complete")
 }

--- a/internal/tablo/tablo_test.go
+++ b/internal/tablo/tablo_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1460,4 +1461,54 @@ func TestRun_PrintBashCompletion_ShortLongFlag(t *testing.T) {
 	_, _ = output.ReadFrom(r)
 
 	assert.Contains(t, output.String(), "complete -F _tablo_completion -- 'tablo'")
+}
+
+func TestRun_DoesNotTreatOutputValueAsBashCompletionFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "--bash-completion")
+
+	os.Args = []string{"tablo", "-o", outputFile, "-version"}
+	resetFlags()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	err = tablo.Run()
+	assert.NoError(t, err)
+	_ = w.Close()
+
+	output := new(BytesWriteCloser)
+	_, _ = output.ReadFrom(r)
+
+	assert.NotContains(t, output.String(), "complete -F _tablo_completion")
+	_, statErr := os.Stat(outputFile)
+	assert.NoError(t, statErr)
+}
+
+func TestRun_DoesNotTreatCompletionFlagAfterPositionalAsCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "users.txt")
+	err := os.WriteFile(inputFile, []byte("hello\n"), 0o600)
+	assert.NoError(t, err)
+
+	os.Args = []string{"tablo", inputFile, "--bash-completion"}
+	resetFlags()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	err = tablo.Run()
+	assert.NoError(t, err)
+	_ = w.Close()
+
+	output := new(BytesWriteCloser)
+	_, _ = output.ReadFrom(r)
+
+	assert.NotContains(t, output.String(), "complete -F _tablo_completion")
 }

--- a/internal/tablo/usage.go
+++ b/internal/tablo/usage.go
@@ -11,8 +11,9 @@ const usage = `usage: %[1]s [-flags] [COLUMN] [COLUMN] [COLUMN]
   flags:
 
   -version                          display version information (%s)
+  --bash-completion                 print bash completion script
   -f, -field-delimiter-char         %s
-                                    (omit for smart split: 2+ whitespace)
+                                     (omit for smart split: 2+ whitespace)
   -l, -line-delimiter-char          %s
                                     (default: "\n")
   -n, -no-separate-rows             %s

--- a/internal/tablo/usage.go
+++ b/internal/tablo/usage.go
@@ -11,7 +11,8 @@ const usage = `usage: %[1]s [-flags] [COLUMN] [COLUMN] [COLUMN]
   flags:
 
   -version                          display version information (%s)
-  --bash-completion                 print bash completion script
+  -bash-completion, --bash-completion
+                                    print bash completion script
   -f, -field-delimiter-char         %s
                                     (omit for smart split: 2+ whitespace)
   -l, -line-delimiter-char          %s

--- a/internal/tablo/usage.go
+++ b/internal/tablo/usage.go
@@ -13,7 +13,7 @@ const usage = `usage: %[1]s [-flags] [COLUMN] [COLUMN] [COLUMN]
   -version                          display version information (%s)
   --bash-completion                 print bash completion script
   -f, -field-delimiter-char         %s
-                                     (omit for smart split: 2+ whitespace)
+                                    (omit for smart split: 2+ whitespace)
   -l, -line-delimiter-char          %s
                                     (default: "\n")
   -n, -no-separate-rows             %s


### PR DESCRIPTION
## Summary
- add bash completion generation via `tablo --bash-completion`
- complete flags, delimiter values, files, and column names from input files
- document the new bash completion flow in help output and README